### PR TITLE
fix high memory usage

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1,16 +1,16 @@
 "use strict"
 
-import { app, protocol, BrowserWindow, Menu, shell, ipcMain, netLog } from "electron"
+import { app, protocol, BrowserWindow, Menu, shell, ipcMain, netLog, crashReporter } from "electron"
 import { createProtocol, installVueDevtools } from "vue-cli-plugin-electron-builder/lib"
 import Utils from "./logic/Utils";
 import ConfigurationManager from "./logic/configuration/ConfigurationManager";
 import { autoUpdater } from "electron-updater";
 import log from "electron-log";
+import path from "path";
+
+app.commandLine.appendSwitch("js-flags", "--max-old-space-size=4096");
 
 const isDevelopment = process.env.NODE_ENV !== "production"
-
-// Increase memory limit for Chromium, must be called before the app is ready.
-app.commandLine.appendSwitch("js-flags", "--max-old-space-size=8192");
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
@@ -22,8 +22,9 @@ protocol.registerSchemesAsPrivileged([{ scheme: "app", privileges: { secure: tru
 async function createWindow() {
     let configManager = new ConfigurationManager(app);
     let config = await configManager.readConfiguration();
+
     // Create the browser window.
-    let options: Electron.BrowserWindowConstructorOptions = {
+    let options = {
         width: 1200,
         height: 1000,
         webPreferences: { nodeIntegration: true, nodeIntegrationInWorker: true },
@@ -194,6 +195,7 @@ app.on("activate", async() => {
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.on("ready", async() => {
+    console.log("READY IS FIRED...");
     if (isDevelopment && !process.env.IS_TEST) {
     // Install Vue Devtools
     // Devtools extensions are broken in Electron 6.0.0 and greater

--- a/src/components/pages/AnalysisPage.vue
+++ b/src/components/pages/AnalysisPage.vue
@@ -2,13 +2,13 @@
     <v-container fluid v-if="!errorStatus && $store.getters.getProject.getAllAssays().length > 0">
         <v-row>
             <v-col>
-<!--                <analysis-summary-->
-<!--                    :assay="activeAssay"-->
-<!--                    :peptide-count-table="activeCountTable"-->
-<!--                    :project="$store.getters.getProject"-->
-<!--                    :peptide-trust="activeTrust"-->
-<!--                    :communication-source="activeCommunicationSource">-->
-<!--                </analysis-summary>-->
+                <analysis-summary
+                    :assay="activeAssay"
+                    :peptide-count-table="activeCountTable"
+                    :project="$store.getters.getProject"
+                    :peptide-trust="activeTrust"
+                    :communication-source="activeCommunicationSource">
+                </analysis-summary>
             </v-col>
         </v-row>
         <v-row>

--- a/src/components/pages/AnalysisPage.vue
+++ b/src/components/pages/AnalysisPage.vue
@@ -2,13 +2,13 @@
     <v-container fluid v-if="!errorStatus && $store.getters.getProject.getAllAssays().length > 0">
         <v-row>
             <v-col>
-                <analysis-summary
-                    :assay="activeAssay"
-                    :peptide-count-table="activeCountTable"
-                    :project="$store.getters.getProject"
-                    :peptide-trust="activeTrust"
-                    :communication-source="activeCommunicationSource">
-                </analysis-summary>
+<!--                <analysis-summary-->
+<!--                    :assay="activeAssay"-->
+<!--                    :peptide-count-table="activeCountTable"-->
+<!--                    :project="$store.getters.getProject"-->
+<!--                    :peptide-trust="activeTrust"-->
+<!--                    :communication-source="activeCommunicationSource">-->
+<!--                </analysis-summary>-->
             </v-col>
         </v-row>
         <v-row>

--- a/src/db/schemas/schema_v1.sql
+++ b/src/db/schemas/schema_v1.sql
@@ -23,7 +23,6 @@ CREATE TABLE pept2data (
     assay_id TEXT NOT NULL,
     peptide TEXT NOT NULL,
     response TEXT,
-    FOREIGN KEY(assay_id) REFERENCES assays(id),
     PRIMARY KEY(assay_id, peptide)
 );
 
@@ -32,7 +31,6 @@ CREATE TABLE peptide_trust (
     missed_peptides TEXT NOT NULL,
     matched_peptides INT NOT NULL,
     searched_peptides INT NOT NULL,
-    FOREIGN KEY(assay_id) REFERENCES assays(id),
     PRIMARY KEY(assay_id)
 );
 
@@ -41,7 +39,5 @@ CREATE TABLE storage_metadata (
     configuration_id INT NOT NULL,
     endpoint TEXT,
     db_version TEXT,
-    FOREIGN KEY(assay_id) REFERENCES assays(id),
-    FOREIGN KEY(configuration_id) REFERENCES search_configuration(id),
     PRIMARY KEY(assay_id)
 );

--- a/src/logic/communication/AssayProcessor.worker.ts
+++ b/src/logic/communication/AssayProcessor.worker.ts
@@ -27,7 +27,6 @@ export function readPept2Data(installationDir: string, dbFile: string, assayId: 
 
         //@ts-ignore
         const db = new Database(dbFile, {}, installationDir);
-        db.pragma("journal_mode = WAL");
 
         let rowsProcessed: number = 0;
         const rows = db.prepare("SELECT * FROM pept2data WHERE `assay_id` = ?").all(assayId);
@@ -72,13 +71,13 @@ export function writePept2Data(
     assayId: string,
     dbFile: string
 ) {
-    console.log(assayId);
-
     const pept2DataResponses = new ShareableMap(0, 0);
     pept2DataResponses.setBuffers(
         peptDataIndexBuffer,
         peptDataDataBuffer
     );
+
+    console.log(dbFile);
 
     //@ts-ignore
     const db = new Database(dbFile, {}, installationDir);

--- a/src/logic/communication/functional/CachedEcResponseCommunicator.ts
+++ b/src/logic/communication/functional/CachedEcResponseCommunicator.ts
@@ -7,6 +7,7 @@ import StaticDatabaseManager from "@/logic/communication/static/StaticDatabaseMa
 export default class CachedEcResponseCommunicator extends EcResponseCommunicator {
     private static codeToResponses: Map<EcCode, EcResponse> = new Map<EcCode, EcResponse>();
     private static processing: Promise<Map<EcCode, EcResponse>>;
+    private static worker;
     private readonly dbFile: string;
 
     constructor() {
@@ -30,8 +31,12 @@ export default class CachedEcResponseCommunicator extends EcResponseCommunicator
             await CachedEcResponseCommunicator.processing;
         }
 
-        const worker = await spawn(new Worker("./CachedEcResponseCommunicator.worker.ts"));
-        CachedEcResponseCommunicator.processing = worker.process(
+        if (!CachedEcResponseCommunicator.worker) {
+            CachedEcResponseCommunicator.worker = await spawn(
+                new Worker("./CachedEcResponseCommunicator.worker.ts")
+            );
+        }
+        CachedEcResponseCommunicator.processing = CachedEcResponseCommunicator.worker.process(
             __dirname,
             this.dbFile,
             codes,

--- a/src/logic/communication/functional/CachedEcResponseCommunicator.worker.ts
+++ b/src/logic/communication/functional/CachedEcResponseCommunicator.worker.ts
@@ -13,8 +13,6 @@ export default function process(
 ): Map<EcCode, EcResponse> {
     // @ts-ignore
     const db = new Database(dbPath, {}, installationDir);
-    db.pragma("journal_mode = WAL");
-
     const stmt = db.prepare("SELECT * FROM ec_numbers WHERE `code` = ?");
 
     for (const code of codes) {

--- a/src/logic/communication/functional/CachedGoResponseCommunicator.ts
+++ b/src/logic/communication/functional/CachedGoResponseCommunicator.ts
@@ -7,6 +7,7 @@ import { GoCode } from "unipept-web-components/src/business/ontology/functional/
 export default class CachedGoResponseCommunicator extends GoResponseCommunicator {
     private static codeToResponses: Map<GoCode, GoResponse> = new Map<GoCode, GoResponse>();
     private static processing: Promise<Map<GoCode, GoResponse>>;
+    private static worker;
     private readonly dbFile: string;
 
     constructor() {
@@ -30,8 +31,12 @@ export default class CachedGoResponseCommunicator extends GoResponseCommunicator
             await CachedGoResponseCommunicator.processing;
         }
 
-        const worker = await spawn(new Worker("./CachedGoResponseCommunicator.worker.ts"));
-        CachedGoResponseCommunicator.processing = worker.process(
+        if (!CachedGoResponseCommunicator.worker) {
+            CachedGoResponseCommunicator.worker = await spawn(
+                new Worker("./CachedGoResponseCommunicator.worker.ts")
+            );
+        }
+        CachedGoResponseCommunicator.processing = CachedGoResponseCommunicator.worker.process(
             __dirname,
             this.dbFile,
             codes,

--- a/src/logic/communication/functional/CachedGoResponseCommunicator.worker.ts
+++ b/src/logic/communication/functional/CachedGoResponseCommunicator.worker.ts
@@ -13,8 +13,6 @@ export default function process(
 ): Map<GoCode, GoResponse> {
     // @ts-ignore
     const db = new Database(dbPath, {}, installationDir);
-    db.pragma("journal_mode = WAL");
-
     const stmt = db.prepare("SELECT * FROM go_terms WHERE `code` = ?");
 
     for (const code of codes) {

--- a/src/logic/communication/functional/CachedInterproResponseCommunicator.ts
+++ b/src/logic/communication/functional/CachedInterproResponseCommunicator.ts
@@ -7,6 +7,7 @@ import { spawn, Worker } from "threads/dist";
 export default class CachedInterproResponseCommunicator extends InterproResponseCommunicator {
     private static codeToResponses: Map<InterproCode, InterproResponse> = new Map<InterproCode, InterproResponse>();
     private static processing: Promise<Map<InterproCode, InterproResponse>>;
+    private static worker;
     private readonly dbFile: string;
 
     constructor() {
@@ -30,8 +31,12 @@ export default class CachedInterproResponseCommunicator extends InterproResponse
             await CachedInterproResponseCommunicator.processing;
         }
 
-        const worker = await spawn(new Worker("./CachedInterproResponseCommunicator.worker.ts"));
-        CachedInterproResponseCommunicator.processing = worker.process(
+        if (!CachedInterproResponseCommunicator.worker) {
+            CachedInterproResponseCommunicator.worker = await spawn(
+                new Worker("./CachedInterproResponseCommunicator.worker.ts")
+            );
+        }
+        CachedInterproResponseCommunicator.processing = CachedInterproResponseCommunicator.worker.process(
             __dirname,
             this.dbFile,
             codes,

--- a/src/logic/communication/functional/CachedInterproResponseCommunicator.worker.ts
+++ b/src/logic/communication/functional/CachedInterproResponseCommunicator.worker.ts
@@ -15,8 +15,6 @@ export default function process(
 ): Map<EcCode, EcResponse> {
     // @ts-ignore
     const db = new Database(dbPath, {}, installationDir);
-    db.pragma("journal_mode = WAL");
-
     const stmt = db.prepare("SELECT * FROM interpro_entries WHERE `code` = ?");
 
     for (const code of codes) {

--- a/src/logic/communication/static/StaticDatabaseManager.ts
+++ b/src/logic/communication/static/StaticDatabaseManager.ts
@@ -172,9 +172,7 @@ export default class StaticDatabaseManager {
      * database file seems not to be present.
      */
     public getDatabase(): DatabaseType {
-        const db = new Database(this.getDatabasePath(), { fileMustExist: true });
-        db.pragma("journal_mode = WAL");
-        return db;
+        return new Database(this.getDatabasePath(), { fileMustExist: true });
     }
 
     public getDatabasePath(): string {

--- a/src/logic/communication/taxonomic/ncbi/CachedNcbiResponseCommunicator.ts
+++ b/src/logic/communication/taxonomic/ncbi/CachedNcbiResponseCommunicator.ts
@@ -12,6 +12,7 @@ export default class CachedNcbiResponseCommunicator extends NcbiResponseCommunic
     private readonly extractStmt: Statement;
     private static codesProcessed: Map<NcbiId, NcbiResponse> = new Map<NcbiId, NcbiResponse>();
     private static processing: Promise<Map<NcbiId, NcbiResponse>>;
+    private static worker;
 
     constructor() {
         super();
@@ -35,8 +36,12 @@ export default class CachedNcbiResponseCommunicator extends NcbiResponseCommunic
 
             const staticDatabaseManager = new StaticDatabaseManager();
 
-            const spawnedProcess = await spawn(new Worker("./CachedNcbiResponseCommunicator.worker.ts"));
-            CachedNcbiResponseCommunicator.processing = spawnedProcess.process(
+            if (!CachedNcbiResponseCommunicator.worker) {
+                CachedNcbiResponseCommunicator.worker = await spawn(
+                    new Worker("./CachedNcbiResponseCommunicator.worker.ts")
+                );
+            }
+            CachedNcbiResponseCommunicator.processing = CachedNcbiResponseCommunicator.worker.process(
                 __dirname,
                 staticDatabaseManager.getDatabasePath(),
                 codes,

--- a/src/logic/communication/taxonomic/ncbi/CachedNcbiResponseCommunicator.worker.ts
+++ b/src/logic/communication/taxonomic/ncbi/CachedNcbiResponseCommunicator.worker.ts
@@ -9,7 +9,6 @@ expose({ process })
 export default function process(installationDir: string, dbPath: string, ncbiIds: NcbiId[], output: Map<NcbiId, NcbiResponse>): Map<NcbiId, NcbiResponse> {
     // @ts-ignore
     const database = new Database(dbPath, {}, installationDir);
-    database.pragma("journal_mode = WAL");
 
     const extractStmt = database.prepare(
         "SELECT * FROM taxons INNER JOIN lineages ON taxons.id = lineages.taxon_id WHERE `id` = ?"

--- a/src/logic/filesystem/assay/AssayFileSystemDestroyer.ts
+++ b/src/logic/filesystem/assay/AssayFileSystemDestroyer.ts
@@ -18,14 +18,14 @@ export default class AssayFileSystemDestroyer extends FileSystemAssayVisitor {
                 fs.unlinkSync(`${this.directoryPath}${assay.getName()}.pep`);
             }
 
-            const configDestroyer = new SearchConfigFileSystemDestroyer(this.db);
-            configDestroyer.visitSearchConfiguration(assay.getSearchConfiguration());
-
             // Also remove all metadata from the db
             this.db.prepare("DELETE FROM pept2data WHERE `assay_id` = ?").run(assay.getId());
             this.db.prepare("DELETE FROM peptide_trust WHERE `assay_id` = ?").run(assay.getId());
             this.db.prepare("DELETE FROM storage_metadata WHERE `assay_id` = ?").run(assay.getId());
             this.db.prepare("DELETE FROM assays WHERE `id` = ?").run(assay.getId());
+
+            const configDestroyer = new SearchConfigFileSystemDestroyer(this.db);
+            configDestroyer.visitSearchConfiguration(assay.getSearchConfiguration());
         } catch (e) {
             throw new IOException(e);
         }

--- a/src/logic/filesystem/project/ProjectManager.ts
+++ b/src/logic/filesystem/project/ProjectManager.ts
@@ -28,7 +28,6 @@ export default class ProjectManager  {
         }
 
         const db = new Database(projectLocation + ProjectManager.DB_FILE_NAME);
-        db.pragma("journal_mode = WAL");
         const project: Project = new Project(projectLocation, db);
 
         // Check all subdirectories of the given project and try to load the studies.
@@ -55,7 +54,6 @@ export default class ProjectManager  {
         }
 
         const db = new Database(projectLocation + ProjectManager.DB_FILE_NAME);
-        db.pragma("journal_mode = WAL");
         db.exec(schema_v1);
 
         await this.addToRecentProjects(projectLocation);


### PR DESCRIPTION
By reusing existing workers as much as possible we can greatly decrease the memory requirements for this app. Memory regularly spiked over 1GiB before but is reduced to requirements between 200MiB and 1GiB right now.

The high memory usage also caused the app to crash regularly due to Chromium memory allocations failing.