### PR TITLE
Offload data table computations

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -292,6 +292,10 @@ export default class App extends Vue implements ErrorListener {
         padding-bottom: 0 !important;
     }
 
+    .v-progress-circular__overlay {
+        transition: none !important;
+    }
+
     //   .container-after-titlebar .v-app-bar {
     //     margin-top: 30px !important;
     //   }

--- a/src/background.ts
+++ b/src/background.ts
@@ -195,7 +195,6 @@ app.on("activate", async() => {
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.on("ready", async() => {
-    console.log("READY IS FIRED...");
     if (isDevelopment && !process.env.IS_TEST) {
     // Install Vue Devtools
     // Devtools extensions are broken in Electron 6.0.0 and greater

--- a/src/components/analysis/PeptideSummaryTable.vue
+++ b/src/components/analysis/PeptideSummaryTable.vue
@@ -128,6 +128,8 @@ export default class PeptideSummaryTable extends Vue {
             );
             await PeptideSummaryTable.worker.setLcaOntology(lcaOntology);
 
+            await PeptideSummaryTable.worker.computeItems();
+
             await this.onOptionsChanged({
                 page: 1,
                 itemsPerPage: 5,

--- a/src/components/analysis/PeptideSummaryTable.worker.ts
+++ b/src/components/analysis/PeptideSummaryTable.worker.ts
@@ -1,0 +1,88 @@
+import { ShareableMap } from "shared-memory-datastructures";
+import { Peptide } from "unipept-web-components/src/business/ontology/raw/Peptide";
+import { expose } from "threads";
+import NcbiTaxon from "unipept-web-components/src/business/ontology/taxonomic/ncbi/NcbiTaxon";
+import { Ontology } from "unipept-web-components/src/business/ontology/Ontology";
+import NcbiOntologyProcessor from "unipept-web-components/src/business/ontology/taxonomic/ncbi/NcbiOntologyProcessor";
+import { DataOptions } from "vuetify";
+
+let pept2DataMap: ShareableMap<Peptide, string>;
+let peptideCountTable: Map<Peptide, number>;
+let peptides: Peptide[];
+let lcaIds: number[];
+let lcaOntology: Ontology<number, NcbiTaxon>;
+
+expose({ setPept2DataMap, setPeptideCountTable, setLcaOntology, getLcaIds, getItems });
+
+function getLcaIds(): number[] {
+    return lcaIds;
+}
+
+function setPept2DataMap(indexBuffer, dataBuffer) {
+    pept2DataMap = new ShareableMap<Peptide, string>(0, 0);
+    pept2DataMap.setBuffers(indexBuffer, dataBuffer);
+}
+
+function setPeptideCountTable(countTable: Map<Peptide, number>) {
+    peptideCountTable = countTable;
+    lcaIds = [];
+
+    peptides = [];
+    for (const peptide of peptideCountTable.keys()) {
+        peptides.push(peptide);
+        const response = pept2DataMap.get(peptide);
+        if (response) {
+            lcaIds.push(JSON.parse(response).lca);
+        }
+    }
+}
+
+function setLcaOntology(ontology: Ontology<number, NcbiTaxon>) {
+    lcaOntology = ontology;
+}
+
+function getItems(options: DataOptions): {
+    peptide: string,
+    count: number,
+    lca: string,
+    matched: boolean
+}[] {
+    try {
+        let output = [];
+        const start = options.itemsPerPage * (options.page - 1);
+        let end = options.itemsPerPage * options.page;
+
+        if (end > peptides.length) {
+            end = peptides.length;
+        }
+
+        // peptides.sort((a: Peptide, b: Peptide) => {
+        //     const sortItem = options.sortBy[0];
+        // });
+
+        for (let i = start; i < end; i++) {
+            const peptide = peptides[i];
+            const response = pept2DataMap.get(peptide);
+            let lcaName: string = "N/A";
+            let matched: boolean = false;
+
+            if (response) {
+                matched = true;
+                // @ts-ignore
+                const lcaDefinition = lcaOntology.definitions.get(JSON.parse(response).lca);
+                lcaName = lcaDefinition ? lcaDefinition.name : lcaName;
+            }
+
+            output.push({
+                peptide: peptide,
+                count: peptideCountTable.get(peptide),
+                lca: lcaName,
+                matched: matched
+            })
+        }
+
+        return output;
+    } catch (err) {
+        console.error(err);
+    }
+}

--- a/src/components/analysis/PeptideSummaryTable.worker.ts
+++ b/src/components/analysis/PeptideSummaryTable.worker.ts
@@ -6,13 +6,21 @@ import { Ontology } from "unipept-web-components/src/business/ontology/Ontology"
 import NcbiOntologyProcessor from "unipept-web-components/src/business/ontology/taxonomic/ncbi/NcbiOntologyProcessor";
 import { DataOptions } from "vuetify";
 
+type ItemType = {
+    peptide: string,
+    count: number,
+    lca: string,
+    matched: boolean
+};
+
 let pept2DataMap: ShareableMap<Peptide, string>;
 let peptideCountTable: Map<Peptide, number>;
 let peptides: Peptide[];
 let lcaIds: number[];
 let lcaOntology: Ontology<number, NcbiTaxon>;
+let items: ItemType[];
 
-expose({ setPept2DataMap, setPeptideCountTable, setLcaOntology, getLcaIds, getItems });
+expose({ setPept2DataMap, setPeptideCountTable, setLcaOntology, getLcaIds, getItems, computeItems });
 
 function getLcaIds(): number[] {
     return lcaIds;
@@ -41,48 +49,57 @@ function setLcaOntology(ontology: Ontology<number, NcbiTaxon>) {
     lcaOntology = ontology;
 }
 
-function getItems(options: DataOptions): {
-    peptide: string,
-    count: number,
-    lca: string,
-    matched: boolean
-}[] {
-    try {
-        let output = [];
-        const start = options.itemsPerPage * (options.page - 1);
-        let end = options.itemsPerPage * options.page;
+function computeItems() {
+    const output = [];
 
-        if (end > peptides.length) {
-            end = peptides.length;
+    for (const peptide of peptides) {
+        const response = pept2DataMap.get(peptide);
+        let lcaName: string = "N/A";
+        let matched: boolean = false;
+
+        if (response) {
+            matched = true;
+            // @ts-ignore
+            const lcaDefinition = lcaOntology.definitions.get(JSON.parse(response).lca);
+            lcaName = lcaDefinition ? lcaDefinition.name : lcaName;
         }
 
-        // peptides.sort((a: Peptide, b: Peptide) => {
-        //     const sortItem = options.sortBy[0];
-        // });
-
-        for (let i = start; i < end; i++) {
-            const peptide = peptides[i];
-            const response = pept2DataMap.get(peptide);
-            let lcaName: string = "N/A";
-            let matched: boolean = false;
-
-            if (response) {
-                matched = true;
-                // @ts-ignore
-                const lcaDefinition = lcaOntology.definitions.get(JSON.parse(response).lca);
-                lcaName = lcaDefinition ? lcaDefinition.name : lcaName;
-            }
-
-            output.push({
-                peptide: peptide,
-                count: peptideCountTable.get(peptide),
-                lca: lcaName,
-                matched: matched
-            })
-        }
-
-        return output;
-    } catch (err) {
-        console.error(err);
+        output.push({
+            peptide: peptide,
+            count: peptideCountTable.get(peptide),
+            lca: lcaName,
+            matched: matched
+        })
     }
+
+    items = output;
+}
+
+function getItems(options: DataOptions): ItemType[] {
+    if (!items) {
+        return [];
+    }
+
+    const start = options.itemsPerPage * (options.page - 1);
+    let end = options.itemsPerPage * options.page;
+
+    if (end > peptides.length) {
+        end = peptides.length;
+    }
+
+    let sortKey = "peptide";
+
+    if (options.sortBy.length > 0) {
+        sortKey = options.sortBy[0];
+    }
+
+    items.sort((a: ItemType, b: ItemType) => {
+        let value: number = a[sortKey] > b[sortKey] ? 1 : -1;
+        if (options.sortDesc.length > 0 && options.sortDesc[0]) {
+            value *= -1;
+        }
+        return value;
+    })
+
+    return items.slice(start, end);
 }

--- a/src/logic/communication/AssayProcessor.worker.ts
+++ b/src/logic/communication/AssayProcessor.worker.ts
@@ -77,8 +77,6 @@ export function writePept2Data(
         peptDataDataBuffer
     );
 
-    console.log(dbFile);
-
     //@ts-ignore
     const db = new Database(dbFile, {}, installationDir);
 


### PR DESCRIPTION
Some data tables need to display a very large amount of items. This could lead to a significant slowdown in rendering and building this table. This PR moves the computation of data items to a separate worker and only provides the items that are currently visible to the table in order to minimize Vue reactivity overhead.