### PR TITLE
More informative placeholders / Smoother UX

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -11,8 +11,6 @@
             <!-- Navigation drawer for managing the currently selected peptides / experiments / etc. Is positioned on
                  the left side -->
             <Toolbar
-                :open.sync="rightNavDrawer"
-                :mini.sync="rightNavMini"
                 v-on:activate-dataset="onActivateDataset"
                 v-on:update:toolbar-width="onToolbarWidthUpdated">
             </Toolbar>
@@ -20,9 +18,9 @@
             <v-content
                 :style="{
                     'min-height': '100%',
-                    'max-width': rightNavMini ? 'calc(100% - 55px)' : 'calc(100% - ' + (toolbarWidth + 55) + 'px)',
+                    'max-width': isMini ? 'calc(100% - 55px)' : 'calc(100% - ' + (toolbarWidth + 55) + 'px)',
                     'position': 'relative',
-                    'left': rightNavMini ? '55px' : (toolbarWidth + 55) + 'px'
+                    'left': isMini ? '55px' : (toolbarWidth + 55) + 'px'
                 }">
                 <router-view style="min-height: 100%;"></router-view>
                 <v-dialog v-model="errorDialog" persistent max-width="600">
@@ -103,13 +101,16 @@ const BrowserWindow = electron.BrowserWindow;
             get(): Project {
                 return this.$store.getters.getProject
             }
+        },
+        isMini: {
+            get(): boolean {
+                return ! ["/analysis/single", "/analysis/multi"].includes(this.$route.path);
+            }
         }
     }
 })
 export default class App extends Vue implements ErrorListener {
     private navDrawer: boolean = false;
-    private rightNavDrawer: boolean = true;
-    private rightNavMini: boolean = true;
     private loading: boolean = true;
 
     private updatingSnackbar: boolean = false;
@@ -131,7 +132,6 @@ export default class App extends Vue implements ErrorListener {
         // should pass through the Vue app.
         ipcRenderer.on("navigate", (sender, location) => {
             if (location !== this.$route.path) {
-                this.rightNavMini = true;
                 this.$router.push(location);
             }
         });

--- a/src/components/navigation-drawers/Toolbar.vue
+++ b/src/components/navigation-drawers/Toolbar.vue
@@ -1,7 +1,6 @@
 <template>
     <div class="toolbar">
         <v-navigation-drawer
-            v-model="isOpen"
             :mini-variant="true"
             fixed :class="{'toolbar-navigation-drawer': !isMini}"
             permanent>
@@ -10,7 +9,7 @@
                     <v-list-item
                         :class="{'v-list-item--active': $route.path === '/'}"
                         link
-                        @click="navigateAndCloseSideBar('/')">
+                        @click="navigate('/', false)">
                         <v-list-item-icon>
                             <v-icon>mdi-home</v-icon>
                         </v-list-item-icon>
@@ -23,7 +22,7 @@
                         :disabled="$store.getters.getProject === null"
                         :class="{'v-list-item--active': $route.path === '/analysis/single'}"
                         link
-                        @click="navigateAndToggleExpand('/analysis/single')">
+                        @click="navigate('/analysis/single', true)">
                         <v-list-item-icon>
                             <v-icon>mdi-bacteria</v-icon>
                         </v-list-item-icon>
@@ -36,7 +35,7 @@
                         :disabled="$store.getters.getProject === null"
                         :class="{'v-list-item--active': $route.path === '/analysis/multi'}"
                         link
-                        @click="navigateAndToggleExpand('/analysis/multi')">
+                        @click="navigate('/analysis/multi', true)">
                         <v-list-item-icon>
                             <v-icon>mdi-test-tube</v-icon>
                         </v-list-item-icon>
@@ -80,66 +79,26 @@ import ToolbarExplorer from "./ToolbarExplorer.vue";
         ComparativeAnalysisToolbar,
         Tooltip,
         SingleAnalysisToolbar
+    },
+    computed: {
+        isMini: {
+            get(): boolean {
+                return ! ["/analysis/single", "/analysis/multi"].includes(this.$route.path);
+            }
+        }
     }
 })
 export default class Toolbar extends Vue {
-    @Prop({ required: false, default: false })
-    private open: boolean;
-    @Prop({ required: false, default: true })
-    private mini: boolean;
-
-    // These are the models that will be used internally by this component to sync the current state.
-    private isOpen: boolean = false;
-    private isMini: boolean = true;
-
     private minToolbarWidth: number = 169;
     private originalToolbarWidth: number = 210;
     private toolbarWidth: number = this.originalToolbarWidth;
 
     mounted() {
-        this.isOpen = this.open;
-        this.isMini = this.mini;
         this.setupDraggableToolbar();
     }
 
-    @Watch("open")
-    private onOpenChanged() {
-        this.isOpen = this.open;
-    }
-
-    @Watch("mini")
-    private onMiniChanged() {
-        this.isMini = this.mini;
-    }
-
-    @Watch("isOpen")
-    private onIsOpenChanged() {
-        this.$emit("update:open", this.isOpen);
-    }
-
-    @Watch("isMini")
-    private onIsMiniChanged() {
-        this.$emit("update:mini", this.isMini);
-    }
-
-    /**
-     * The visibility of the sidebar should only toggle when the current route is the same as the route that a
-     * component click should lead to.
-     */
-    private navigateAndToggleExpand(routeToGo: string) {
-        if (this.$route.path === routeToGo) {
-            // The toolbar content is only expanded when the current page is already activated. (The toolbar does
-            // not expand when navigation takes place).
-            this.isMini = !this.isMini;
-        } else {
-            // If the user does wan't to navigate, we change the current path.
-            this.$router.replace(routeToGo);
-        }
-    }
-
-    private navigateAndCloseSideBar(routeToGo: string) {
+    private navigate(routeToGo: string, activateSidebar: boolean) {
         if (this.$route.path !== routeToGo) {
-            this.isMini = true;
             this.$router.replace(routeToGo);
         }
     }

--- a/src/components/pages/AnalysisPage.vue
+++ b/src/components/pages/AnalysisPage.vue
@@ -49,22 +49,43 @@
                 <a @click="reanalyse()">try again.</a>
             </p>
         </div>
-        <div class="inner-status-container" v-else-if="$store.getters.getProject.getAllAssays().length === 0">
-            <v-icon x-large>
-                mdi-flask-empty-plus-outline
-            </v-icon>
+        <div class="d-flex flex-column mt-12" style="max-width: 1000px;" v-else-if="$store.getters.getProject.getAllAssays().length === 0">
+            <h2>Empty project</h2>
             <p>
-                Please add at least one study with one assay to this project.
+                You have created an empty project. If this is the first time you're using this application, you can use
+                the following steps as a guide to get started.
+            </p>
+            <h3>1. Create a new study</h3>
+            <p class="font-italic font-weight-light">
+                A study is a central concept that contains information about the subject that's under investigation.
+                It's a collection of assays with extra contextual information about these assays.
+            </p>
+            <p class="font-weight-medium">
+                Click the "Create assay" button in the sidebar to the left to create a new study. This is the big blue
+                button situated at the bottom of the sidebar.
+            </p>
+            <h3>2. Add an assay to your study</h3>
+            <p class="font-italic font-weight-light">
+                An assay corresponds to one experiment executed on a piece of material or a dataset. In the case of
+                metaproteomics, an assay corresponds to a list of peptides with a specific search configuration that
+                can directly be processed by this application.
+            </p>
+            <p class="font-weight-medium">
+                After you've created a new study, you need to import a list of peptides that you want to process. Click
+                the <v-icon small style="position: relative; bottom: 1px;" color="grey darken-3">
+                mdi-file-plus-outline</v-icon> button next to the study to which your new assay should belong.
+            </p>
+            <p class="font-italic">
+                Tip: you can create as many studies and assays as you'd like.
             </p>
         </div>
-        <div class="inner-status-container game-container" v-else-if="maxProgress < 1 || activeProgress < 1" >
+        <div class="inner-status-container game-container mt-12" v-else-if="maxProgress < 1 || activeProgress < 1" >
             <v-progress-circular
                 :size="100"
                 :rotate="-90"
                 :width="15"
                 :value="(activeAssay ? activeProgress : maxProgress) * 100"
-                color="primary"
-                class="mt-12">
+                color="primary">
                 {{ Math.round((activeAssay ? activeProgress : maxProgress) * 100) }}%
             </v-progress-circular>
             <p class="mt-4">

--- a/src/components/pages/AnalysisPage.vue
+++ b/src/components/pages/AnalysisPage.vue
@@ -61,7 +61,7 @@
                 It's a collection of assays with extra contextual information about these assays.
             </p>
             <p class="font-weight-medium">
-                Click the "Create assay" button in the sidebar to the left to create a new study. This is the big blue
+                Click the "Create study" button in the sidebar to the left to create a new study. This is the big blue
                 button situated at the bottom of the sidebar.
             </p>
             <h3>2. Add an assay to your study</h3>

--- a/src/components/pages/HomePage.vue
+++ b/src/components/pages/HomePage.vue
@@ -23,14 +23,14 @@
                         <div class="project-actions">
                             <tooltip message="Select an empty folder and create a new project." position="bottom">
                                 <div @click="createProject()">
-                                    <v-icon>mdi-folder-plus-outline</v-icon>
-                                    <span>Create new project</span>
+                                    <v-icon large>mdi-folder-plus-outline</v-icon>
+                                    <span style="font-size: 24px;">Create new project</span>
                                 </div>
                             </tooltip>
                             <tooltip message="Import a project from an external model." position="bottom">
                                 <div>
-                                    <v-icon>mdi-folder-download-outline</v-icon>
-                                    <span>Import project</span>
+                                    <v-icon large>mdi-folder-download-outline</v-icon>
+                                    <span style="font-size: 24px;">Import project</span>
                                 </div>
                             </tooltip>
                         </div>

--- a/src/components/project/RecentProjects.vue
+++ b/src/components/project/RecentProjects.vue
@@ -22,6 +22,15 @@
                 </v-list-item>
             </v-list>
         </div>
+        <div v-else class="ml-12 mr-12">
+            <h2>No recent projects</h2>
+            <p class="font-weight-medium">
+                Click the button below to open a previously created project or chose one of the options on the right.
+                You can create a new, empty project by selecting the "Create new project" button. If you want to
+                import an existing project from an external model (for example ISA-tab), you need to click the "Import
+                project" button.
+            </p>
+        </div>
         <tooltip message="Select a previously created project to open." position="bottom">
             <div class="open-project-button" @click="openProject()">
                 <v-icon>mdi-folder-open-outline</v-icon>


### PR DESCRIPTION
This PR replaces the "not-so-ideal" placeholders that were present in the application with more informative and useful variants:

Screenshots:
![image](https://user-images.githubusercontent.com/9608686/83944070-1a6ce800-a801-11ea-8583-cf5f0a9d62ae.png)

![image](https://user-images.githubusercontent.com/9608686/83944078-1f319c00-a801-11ea-8d46-8ee4a26afd6b.png)

**Main changes:**
* Instead of simply displaying nothing or an obvious text, the placeholders now help to guide a first time user through the application.
* The sidebar can now also no longer be closed. A sidebar that constantly pops open only leads to confusion.
* The size of the "create project" and "import project" buttons on the homepage has been increased to make these more prominent.