### PR TITLE
Ask user for search configuration before analysis

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -27,13 +27,13 @@
                     <v-card>
                         <v-card-title>Synchronization error</v-card-title>
                         <v-card-text>
-                            Could not synchronize your latest changes with the local disk. Please retry or restart the
-                            application if this problem persists.
+                            Could not synchronize your latest changes with the local disk. Please restart the
+                            application if the problem persists.
                         </v-card-text>
                         <v-card-actions>
                             <v-spacer></v-spacer>
-                            <v-btn color="error" text @click="errorDialog = false">Exit application</v-btn>
-                            <v-btn color="primary" text @click="errorDialog = false">Retry</v-btn>
+                            <v-btn color="error" text @click="closeApplication">Exit application</v-btn>
+                            <v-btn color="primary" text @click="errorDialog = false">Ignore</v-btn>
                         </v-card-actions>
                     </v-card>
                 </v-dialog>
@@ -222,6 +222,11 @@ export default class App extends Vue implements ErrorListener {
             console.error(err)
         }
         this.loading = false;
+    }
+
+    private async closeApplication() {
+        let w = electron.remote.getCurrentWindow();
+        w.close();
     }
 
     private onToolbarWidthUpdated(newValue: number) {

--- a/src/components/assay/CreateAssay.vue
+++ b/src/components/assay/CreateAssay.vue
@@ -20,6 +20,9 @@ import DatasetForm from "unipept-web-components/src/components/dataset/DatasetFo
 import Project from "@/logic/filesystem/project/Project";
 import Study from "unipept-web-components/src/business/entities/study/Study";
 import Assay from "unipept-web-components/src/business/entities/assay/Assay";
+import ProteomicsAssay from "unipept-web-components/src/business/entities/assay/ProteomicsAssay";
+import AssayFileSystemDataWriter from "@/logic/filesystem/assay/AssayFileSystemDataWriter";
+import { v4 as uuidv4 } from "uuid";
 
 @Component({
     components: {
@@ -35,12 +38,11 @@ export default class CreateAssay extends Vue {
     private name: string;
 
     private async createAssay() {
-        // const assay: Assay = this.project.createMetaProteomicsAssay(
-        //     this.name,
-        //     this.peptides.split(/\r?\n/),
-        //     this.study
-        // );
-        // this.$emit("create-assay", assay);
+        const assay: ProteomicsAssay = new ProteomicsAssay(uuidv4());
+        assay.setName(this.name);
+        assay.setPeptides(this.peptides.split(/\r?\n/));
+
+        this.$emit("create-assay", assay);
     }
 }
 </script>

--- a/src/components/dialogs/SearchConfigurationDialog.vue
+++ b/src/components/dialogs/SearchConfigurationDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <v-dialog v-model="dialogActive" max-width="600">
+    <v-dialog v-model="dialogActive" max-width="600" persistent>
         <v-card>
             <v-card-title>
                 Search configuration
@@ -49,7 +49,7 @@ export default class SearchConfigurationDialog extends Vue {
      * What function should be executed after the user clicked OK?
      */
     @Prop({ required: false, default: async() => {
-        return; 
+        return;
     } })
     private callback: () => Promise<void>;
 

--- a/src/components/dialogs/SearchConfigurationDialog.vue
+++ b/src/components/dialogs/SearchConfigurationDialog.vue
@@ -1,0 +1,80 @@
+<template>
+    <v-dialog v-model="dialogActive" max-width="600">
+        <v-card>
+            <v-card-title>
+                Search configuration
+            </v-card-title>
+            <v-card-text>
+                <p>
+                    Please configure the search settings that should be applied to this sample. Note that enabling the
+                    <span class="font-italic">advanced missed cleavage handling</span> setting has a serious performance
+                    impact and leads to a slower analysis!
+                </p>
+                <search-settings-form
+                    :horizontal="false"
+                    :equate-il.sync="equateIl"
+                    :filter-duplicates.sync="filterDuplicates"
+                    :missing-cleavage.sync="missedCleavage">
+                </search-settings-form>
+                <div class="d-flex justify-center mt-4">
+                    <v-btn color="primary" @click="setConfig">
+                        Start analysis
+                    </v-btn>
+                </div>
+            </v-card-text>
+        </v-card>
+    </v-dialog>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import Component from "vue-class-component";
+import { Prop, Watch } from "vue-property-decorator";
+import ProteomicsAssay from "unipept-web-components/src/business/entities/assay/ProteomicsAssay";
+import SearchSettingsForm from "unipept-web-components/src/components/analysis/SearchSettingsForm.vue";
+import SearchConfiguration from "unipept-web-components/src/business/configuration/SearchConfiguration";
+import { AssayFileSystemMetaDataWriter } from "@/logic/filesystem/assay/AssayFileSystemMetaDataWriter";
+
+@Component({
+    components: {
+        SearchSettingsForm
+    }
+})
+export default class SearchConfigurationDialog extends Vue {
+    @Prop({ required: true })
+    private value: boolean;
+    @Prop({ required: true })
+    private assay: ProteomicsAssay;
+    /**
+     * What function should be executed after the user clicked OK?
+     */
+    @Prop({ required: false, default: async() => {
+        return; 
+    } })
+    private callback: () => Promise<void>;
+
+    private dialogActive: boolean = false;
+
+    private equateIl: boolean = true;
+    private filterDuplicates: boolean = true;
+    private missedCleavage: boolean = false;
+
+
+    @Watch("value")
+    private async onValueChanged() {
+        this.dialogActive = this.value;
+    }
+
+    private async setConfig() {
+        const config = new SearchConfiguration(this.equateIl, this.filterDuplicates, this.missedCleavage);
+        this.assay.setSearchConfiguration(config);
+        await this.callback();
+        this.dialogActive = false;
+        this.$emit("input", this.dialogActive);
+    }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/src/components/navigation-drawers/AssayItem.vue
+++ b/src/components/navigation-drawers/AssayItem.vue
@@ -106,6 +106,8 @@ import ProteomicsAssay from "unipept-web-components/src/business/entities/assay/
 import Project from "@/logic/filesystem/project/Project";
 import AssayFileSystemDestroyer from "@/logic/filesystem/assay/AssayFileSystemDestroyer";
 import { promises as fs } from "fs";
+import { v4 as uuidv4 } from "uuid";
+import { AssayFileSystemMetaDataWriter } from "@/logic/filesystem/assay/AssayFileSystemMetaDataWriter";
 
 
 const { remote } = require("electron");
@@ -259,6 +261,17 @@ export default class AssayItem extends Vue {
             }
             assayName = newName;
         }
+
+        // Also copy configuration for this assay.
+        const newAssay = new ProteomicsAssay(uuidv4());
+        newAssay.setName(assayName);
+        newAssay.setSearchConfiguration(this.assay.getSearchConfiguration());
+        const metadataWriter = new AssayFileSystemMetaDataWriter(
+            `${this.project.projectPath}${this.study.getName()}`,
+            this.project.db,
+            this.study
+        );
+        await newAssay.accept(metadataWriter);
 
         await fs.copyFile(
             `${this.project.projectPath}${this.study.getName()}/${this.assay.getName()}.pep`,

--- a/src/logic/communication/AssayProcessor.ts
+++ b/src/logic/communication/AssayProcessor.ts
@@ -43,7 +43,6 @@ export default class AssayProcessor {
         await this.updateStorageMetadata();
 
         this.setProgress(1);
-        console.log("Done loading: " + new Date().getTime());
         return [peptideCountTable, new CachedCommunicationSource(
             pept2DataResponses,
             peptideTrust,

--- a/src/logic/filesystem/assay/AssayFileSystemMetaDataReader.ts
+++ b/src/logic/filesystem/assay/AssayFileSystemMetaDataReader.ts
@@ -1,14 +1,32 @@
-import { Statement } from "better-sqlite3";
+import { Database, Statement } from "better-sqlite3";
 import FileSystemAssayVisitor from "@/logic/filesystem/assay/FileSystemAssayVisitor";
 import ProteomicsAssay from "unipept-web-components/src/business/entities/assay/ProteomicsAssay";
 import SearchConfiguration from "unipept-web-components/src/business/configuration/SearchConfiguration";
 import SearchConfigFileSystemReader from "@/logic/filesystem/configuration/SearchConfigFileSystemReader";
+import Study from "unipept-web-components/src/business/entities/study/Study";
 
 export default class AssayFileSystemMetaDataReader extends FileSystemAssayVisitor {
+    constructor(
+        directoryPath: string,
+        db: Database,
+        private readonly study?: Study
+    ) {
+        super(directoryPath, db);
+    }
+
     public async visitProteomicsAssay(mpAssay: ProteomicsAssay): Promise<void> {
-        const row = this.db.prepare("SELECT * FROM assays WHERE assays.id = ?").get(mpAssay.getId());
+        let row = this.db.prepare("SELECT * FROM assays WHERE assays.id = ?").get(mpAssay.getId());
+
+        if (!row && this.study) {
+            // Try to find information about this assay by name and study id.
+            row = this.db.prepare("SELECT * FROM assays WHERE name = ? AND study_id = ?").get(
+                mpAssay.getName(),
+                this.study.getId()
+            );
+        }
 
         if (row) {
+            mpAssay.id = row.id;
             const configuration = new SearchConfiguration(true, true, false, row.configuration_id);
             const configReader = new SearchConfigFileSystemReader(this.db);
             configReader.visitSearchConfiguration(configuration);

--- a/src/logic/filesystem/assay/FileSystemAssayChangeListener.ts
+++ b/src/logic/filesystem/assay/FileSystemAssayChangeListener.ts
@@ -38,7 +38,7 @@ export default class FileSystemAssayChangeListener implements ChangeListener<Pro
         );
 
         await mkdirp(`${this.getAssayDirectory()}`);
-        console.log("Renaming file to: " + `${this.getAssayDirectory()}${newName}.pep`);
+
         // Rename metadata file
         fs.renameSync(
             `${this.getAssayDirectory()}${oldName}.pep`,

--- a/src/logic/filesystem/project/FileSystemWatcher.ts
+++ b/src/logic/filesystem/project/FileSystemWatcher.ts
@@ -15,6 +15,7 @@ import StudyFileSystemDataReader from "@/logic/filesystem/study/StudyFileSystemD
 import FileSystemStudyChangeListener from "@/logic/filesystem/study/FileSystemStudyChangeListener";
 import FileSystemAssayChangeListener from "@/logic/filesystem/assay/FileSystemAssayChangeListener";
 import StudyFileSystemRemover from "@/logic/filesystem/study/StudyFileSystemRemover";
+import AssayFileSystemMetaDataReader from "@/logic/filesystem/assay/AssayFileSystemMetaDataReader";
 
 /**
  * The FileSystemWatcher is responsible for the synchronization of a project with the disk. It watches the filesystem
@@ -51,7 +52,7 @@ export default class FileSystemWatcher {
     }
 
     /**
-     * This function must be invoked whenever a file was added to the local file system. TWe
+     * This function must be invoked whenever a file was added to the local file system.
      * @param filePath
      */
     private async fileAdded(filePath: string) {
@@ -81,6 +82,14 @@ export default class FileSystemWatcher {
                 );
                 assay.setName(assayName);
 
+                // Read metadata from disk if it exists.
+                const assayMetaReader = new AssayFileSystemMetaDataReader(
+                    this.project.projectPath + studyName,
+                    this.project.db,
+                    study
+                );
+                await assay.accept(assayMetaReader);
+
                 // Read peptides from disk for this assay
                 const assayReader: FileSystemAssayVisitor = new AssayFileSystemDataReader(
                     this.project.projectPath + studyName,
@@ -97,8 +106,8 @@ export default class FileSystemWatcher {
                 );
 
                 await assay.accept(assayWriter);
-                // This study should already have a change listener, which takes care of processing the assay as soon as it
-                // is added to the study.
+                // This study should already have a change listener, which takes care of processing the assay as soon as
+                // it is added to the study.
                 study.addAssay(assay);
             }
         } catch (err) {

--- a/src/logic/filesystem/project/Project.ts
+++ b/src/logic/filesystem/project/Project.ts
@@ -145,7 +145,6 @@ export default class Project {
                 {
                     onProgressUpdate: (progress: number) => {
                         if (!processedItem.startProcessingTime) {
-                            console.log("Update start time...");
                             processedItem.startProcessingTime = new Date().getTime();
                         }
 

--- a/src/logic/filesystem/project/ProjectManager.ts
+++ b/src/logic/filesystem/project/ProjectManager.ts
@@ -26,7 +26,6 @@ export default class ProjectManager  {
      * @throws {InvalidProjectException} When the given directory does not contain all required project files.
      */
     public async loadExistingProject(projectLocation: string): Promise<Project> {
-        console.log("Start loading: " + new Date().getTime());
         if (!projectLocation.endsWith("/")) {
             projectLocation += "/";
         }


### PR DESCRIPTION
This PR introduces a new enhancement in which the user first needs to indicate what search settings he wants to apply before the analysis of an assay starts. This fixes issue #62.

Screenshots:
![image](https://user-images.githubusercontent.com/9608686/84027058-ab24fe80-a98e-11ea-9bf2-58f7680a7a53.png)
