### PR TITLE
Keep track of analysis metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17270,8 +17270,9 @@
       "integrity": "sha512-g9AM+44twT+qQpg4kHhupamMoBr4QscjqjQY8Pdk7cdWHvZs5HuIVTNtH44IbAtN08x9+U3BTT+lp+ZEJpaoFw=="
     },
     "unipept-web-components": {
-      "version": "file:unipept-web-components-1.2.1.tgz",
-      "integrity": "sha512-AKfeU4hjzT2LOpBG8612RdjIX8RAjIrHqa7YXV0fL442u5jW0yRlDrBLbrwD4qRgOd8HVs9RwuaCeKEnqa1bUg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/unipept-web-components/-/unipept-web-components-1.2.2.tgz",
+      "integrity": "sha512-qQUG9M+QzB8ncNfABkHWvPJlXDJeXN3XldFCjjRZk4jIHEb2/PyLT0hwfWFGGZphV97dAZNX7CSz2heyO5fHkg==",
       "requires": {
         "async": "^3.2.0",
         "axios": "^0.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17270,9 +17270,8 @@
       "integrity": "sha512-g9AM+44twT+qQpg4kHhupamMoBr4QscjqjQY8Pdk7cdWHvZs5HuIVTNtH44IbAtN08x9+U3BTT+lp+ZEJpaoFw=="
     },
     "unipept-web-components": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/unipept-web-components/-/unipept-web-components-1.2.1.tgz",
-      "integrity": "sha512-JdnK57f5wQICx3Jj3l3xw7JJ9Kfjd5PBE/cVKioEMKEqo+zqcB1pzGD0Tc8RN87Roaz1da0GVRPoEqa6kSKSIQ==",
+      "version": "file:unipept-web-components-1.2.1.tgz",
+      "integrity": "sha512-AKfeU4hjzT2LOpBG8612RdjIX8RAjIrHqa7YXV0fL442u5jW0yRlDrBLbrwD4qRgOd8HVs9RwuaCeKEnqa1bUg==",
       "requires": {
         "async": "^3.2.0",
         "axios": "^0.19.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "regenerator-runtime": "^0.13.3",
     "shared-memory-datastructures": "0.1.8",
     "threads": "^1.4.1",
-    "unipept-web-components": "1.2.1",
+    "unipept-web-components": "file:unipept-web-components-1.2.1.tgz",
     "uuid": "^7.0.3",
     "vue": "^2.6.12",
     "vue-class-component": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unipept-desktop",
-  "version": "0.2.2",
+  "version": "0.3.1",
   "private": true,
   "author": "Unipept Team (Ghent University)",
   "description": "A desktop equivalent of unipept.ugent.be. This app aims at high-throughput analysis of metaproteomics samples.",
@@ -47,7 +47,7 @@
     "regenerator-runtime": "^0.13.3",
     "shared-memory-datastructures": "0.1.8",
     "threads": "^1.4.1",
-    "unipept-web-components": "file:unipept-web-components-1.2.1.tgz",
+    "unipept-web-components": "1.2.2",
     "uuid": "^7.0.3",
     "vue": "^2.6.12",
     "vue-class-component": "^7.1.0",

--- a/src/components/analysis/AnalysisSummary.vue
+++ b/src/components/analysis/AnalysisSummary.vue
@@ -187,7 +187,7 @@ export default class AnalysisSummary extends Vue {
     private update() {
         const config = new SearchConfiguration(this.equateIl, this.filterDuplicates, this.missedCleavage);
         this.assay.setSearchConfiguration(config);
-        this.$store.dispatch("processAssay", this.assay);
+        this.$store.dispatch("processAssay", [this.assay, true]);
     }
 
     private getHumanReadableAssayDate(): string {

--- a/src/components/navigation-drawers/AssayItem.vue
+++ b/src/components/navigation-drawers/AssayItem.vue
@@ -314,7 +314,7 @@ export default class AssayItem extends Vue {
     }
 
     private reanalyse() {
-        this.$store.dispatch("processAssay", this.assay);
+        this.$store.dispatch("processAssay", [this.assay, true]);
     }
 
     private selectAssay() {

--- a/src/components/pages/AnalysisPage.vue
+++ b/src/components/pages/AnalysisPage.vue
@@ -178,7 +178,7 @@ export default class AnalysisPage extends Vue {
 
     private reanalyse() {
         if (this.activeAssay) {
-            this.$store.dispatch("processAssay", this.activeAssay);
+            this.$store.dispatch("processAssay", [this.activeAssay, true]);
         }
     }
 

--- a/src/db/schemas/schema_v1.sql
+++ b/src/db/schemas/schema_v1.sql
@@ -7,11 +7,7 @@ CREATE TABLE assays (
     id TEXT PRIMARY KEY,
     name TEXT NOT NULL,
     study_id TEXT NOT NULL,
-    configuration_id INT NOT NULL,
-    endpoint TEXT,
-    db_version TEXT,
-    FOREIGN KEY(study_id) REFERENCES studies(id),
-    FOREIGN KEY(configuration_id) REFERENCES search_configuration(id) ON DELETE CASCADE
+    FOREIGN KEY(study_id) REFERENCES studies(id)
 );
 
 CREATE TABLE search_configuration (
@@ -41,5 +37,7 @@ CREATE TABLE storage_metadata (
     configuration_id INT NOT NULL,
     endpoint TEXT,
     db_version TEXT,
-    PRIMARY KEY(assay_id)
+    analysis_date TEXT,
+    PRIMARY KEY(assay_id),
+    FOREIGN KEY(configuration_id) REFERENCES search_configuration(id)
 );

--- a/src/logic/communication/DesktopAssayProcessor.ts
+++ b/src/logic/communication/DesktopAssayProcessor.ts
@@ -8,13 +8,16 @@ import {
     PeptideTrust,
     AssayProcessor,
     PeptideData,
-    NetworkConfiguration
+    NetworkConfiguration,
+    DateUtils
 } from "unipept-web-components";
 
 import CachedCommunicationSource from "@/logic/communication/source/CachedCommunicationSource";
 import ProcessedAssayManager from "@/logic/filesystem/assay/processed/ProcessedAssayManager";
 import { Database } from "better-sqlite3";
 import { ShareableMap } from "shared-memory-datastructures";
+import StaticDatabaseManager from "@/logic/communication/static/StaticDatabaseManager";
+import MetadataCommunicator from "@/logic/communication/metadata/MetadataCommunicator";
 
 export default class DesktopAssayProcessor implements AssayProcessor {
     private pept2DataCommunicator: Pept2DataCommunicator;
@@ -85,8 +88,10 @@ export default class DesktopAssayProcessor implements AssayProcessor {
                     this.assay.getSearchConfiguration()
                 );
 
+                const currentDbVersion: string = await MetadataCommunicator.getRemoteUniprotVersion();
+
                 this.assay.setEndpoint(NetworkConfiguration.BASE_URL);
-                this.assay.setDatabaseVersion("N/A");
+                this.assay.setDatabaseVersion(currentDbVersion);
 
                 // Store results and update metadata...
                 await processedAssayManager.storeProcessingResults(this.assay, pept2ResponseMap, trust);

--- a/src/logic/communication/metadata/MetadataCommunicator.ts
+++ b/src/logic/communication/metadata/MetadataCommunicator.ts
@@ -1,0 +1,16 @@
+import { NetworkConfiguration, NetworkUtils } from "unipept-web-components";
+
+export default class MetadataCommunicator {
+    private static METADATA_ENDPOINT: string = "/private_api/metadata";
+
+    public static async getRemoteUniprotVersion(): Promise<string>  {
+        try {
+            const result = await NetworkUtils.getJSON(
+                NetworkConfiguration.BASE_URL + MetadataCommunicator.METADATA_ENDPOINT
+            );
+            return "UniProt " + result["db_version"];
+        } catch (err) {
+            return "N/A";
+        }
+    }
+}

--- a/src/logic/filesystem/assay/AssayFileSystemMetaDataWriter.ts
+++ b/src/logic/filesystem/assay/AssayFileSystemMetaDataWriter.ts
@@ -16,14 +16,6 @@ export class AssayFileSystemMetaDataWriter extends FileSystemAssayVisitor {
     }
 
     private saveAssayMetaData(mpAssay: ProteomicsAssay): void {
-        // Check if this study was saved before.
-        const queryResults = this.db.prepare(
-            `
-                SELECT * FROM assays 
-                INNER JOIN search_configuration ON assays.configuration_id = search_configuration.id WHERE assays.id = ?
-            `
-        ).get(mpAssay.getId());
-
         let searchConfig = mpAssay.getSearchConfiguration();
         if (!searchConfig) {
             searchConfig = new SearchConfiguration();
@@ -33,33 +25,22 @@ export class AssayFileSystemMetaDataWriter extends FileSystemAssayVisitor {
         const searchConfigWriter = new SearchConfigFileSystemWriter(this.db);
         searchConfigWriter.visitSearchConfiguration(searchConfig);
 
-        console.log("Setting endpoint to: " + mpAssay.getEndpoint());
+        this.db.prepare(
+            "REPLACE INTO assays (id, name, study_id) VALUES (?, ?, ?)"
+        ).run(
+            mpAssay.getId(),
+            mpAssay.getName(),
+            this.study.getId()
+        );
 
-        if (queryResults) {
-            this.db.prepare(
-                "UPDATE assays SET name = ?, study_id = ?, configuration_id = ?, endpoint = ?, db_version = ? WHERE id = ?"
-            ).run(
-                mpAssay.getName(),
-                this.study.getId(),
-                searchConfig.id,
-                mpAssay.getEndpoint(),
-                mpAssay.getDatabaseVersion(),
-                mpAssay.id
-            );
-        } else {
-            this.db.prepare(
-                "INSERT INTO assays (id, name, study_id, configuration_id, endpoint, db_version) VALUES (?, ?, ?, ?, ?, ?)"
-            ).run(
-                mpAssay.getId(),
-                mpAssay.getName(),
-                this.study.getId(),
-                searchConfig.id,
-                mpAssay.getEndpoint(),
-                mpAssay.getDatabaseVersion()
-            );
-        }
-
-        console.log("Now in db: ");
-        console.log(this.db.prepare("SELECT * FROM assays WHERE id = ?").get(mpAssay.getId()));
+        this.db.prepare(
+            "REPLACE INTO storage_metadata (assay_id, configuration_id, endpoint, db_version, analysis_date) VALUES (?, ?, ?, ?, ?)"
+        ).run(
+            mpAssay.getId(),
+            searchConfig.id,
+            mpAssay.getEndpoint(),
+            mpAssay.getDatabaseVersion(),
+            mpAssay.getDate().toJSON()
+        )
     }
 }

--- a/src/logic/filesystem/assay/FileSystemAssayChangeListener.ts
+++ b/src/logic/filesystem/assay/FileSystemAssayChangeListener.ts
@@ -58,12 +58,15 @@ export default class FileSystemAssayChangeListener implements ChangeListener<Pro
     }
 
     private async serializeData(assay: ProteomicsAssay): Promise<void> {
-        const writer: FileSystemAssayVisitor = new AssayFileSystemDataWriter(this.getAssayDirectory(), store.getters.database);
+        const writer: FileSystemAssayVisitor = new AssayFileSystemDataWriter(
+            this.getAssayDirectory(),
+            store.getters.database
+        );
 
         await assay.accept(writer);
 
         // noinspection ES6MissingAwait
-        store.dispatch("processAssay", assay);
+        store.dispatch("processAssay", [assay, false]);
     }
 
     private getAssayDirectory(): string {

--- a/src/logic/filesystem/assay/processed/ProcessedAssayManager.ts
+++ b/src/logic/filesystem/assay/processed/ProcessedAssayManager.ts
@@ -61,17 +61,6 @@ export default class ProcessedAssayManager {
             return null;
         }
 
-        const currentStaticDb: string = await MetadataCommunicator.getRemoteUniprotVersion();
-        const currentEndpoint: string = NetworkConfiguration.BASE_URL;
-
-        // Check if the database version and endpoint are equal
-        if (
-            currentStaticDb !== row.db_version ||
-            currentEndpoint !== row.endpoint
-        ) {
-            return null;
-        }
-
         // Now try to read the serialized pept2data from the database
         const result: [
             TransferDescriptor,

--- a/src/logic/filesystem/assay/processed/ProcessedAssayManager.worker.ts
+++ b/src/logic/filesystem/assay/processed/ProcessedAssayManager.worker.ts
@@ -39,8 +39,8 @@ export function readPept2Data(
 
 export function writePept2Data(
     installationDir: string,
-    peptDataIndexBuffer: SharedArrayBuffer,
-    peptDataDataBuffer: SharedArrayBuffer,
+    peptDataIndexBuffer: ArrayBuffer,
+    peptDataDataBuffer: ArrayBuffer,
     peptideTrust: PeptideTrust,
     assayId: string,
     dbFile: string

--- a/src/logic/filesystem/project/FileSystemWatcher.ts
+++ b/src/logic/filesystem/project/FileSystemWatcher.ts
@@ -114,7 +114,7 @@ export default class FileSystemWatcher {
                 // it is added to the study.
                 study.addAssay(assay);
                 await store.dispatch("addAssay", assay);
-                store.dispatch("processAssay", assay);
+                store.dispatch("processAssay", [assay, false]);
             }
         } catch (err) {
             this.reportError(err);
@@ -150,7 +150,7 @@ export default class FileSystemWatcher {
             for (const assay of study.getAssays()) {
                 await store.dispatch("addAssay", assay);
                 // noinspection ES6MissingAwait
-                store.dispatch("processAssay", assay);
+                store.dispatch("processAssay", [assay, false]);
             }
 
             study.addChangeListener(new FileSystemStudyChangeListener());

--- a/src/logic/filesystem/study/FileSystemStudyChangeListener.ts
+++ b/src/logic/filesystem/study/FileSystemStudyChangeListener.ts
@@ -50,7 +50,11 @@ export default class FileSystemStudyChangeListener implements ChangeListener<Stu
 
     private async createAssay(study: Study, assay: Assay): Promise<void> {
         const path: string = `${store.getters.projectLocation}${study.getName()}/`;
-        const metaDataWriter: FileSystemAssayVisitor = new AssayFileSystemMetaDataWriter(path, store.getters.database, study);
+        const metaDataWriter: FileSystemAssayVisitor = new AssayFileSystemMetaDataWriter(
+            path,
+            store.getters.database,
+            study
+        );
         const dataWriter: FileSystemAssayVisitor = new AssayFileSystemDataWriter(path, store.getters.database);
 
         await assay.accept(metaDataWriter);

--- a/src/state/ProjectStore.ts
+++ b/src/state/ProjectStore.ts
@@ -107,7 +107,7 @@ const projectActions: ActionTree<ProjectState, any> = {
         for (const study of studies) {
             for (const assay of study.getAssays()) {
                 await store.dispatch("addAssay", assay);
-                store.dispatch("processAssay", assay);
+                store.dispatch("processAssay", [assay, false]);
             }
         }
 


### PR DESCRIPTION
This PR introduces the functionality to keep track of the technical metadata associated with an analysis (i.e. which endpoint was used, which UniProt version was used, which search settings were used, ...). 

If all settings remain the same, the analysis summary looks like this:
![image](https://user-images.githubusercontent.com/9608686/94803363-75969c00-03e9-11eb-83cf-249bd19f38dc.png)

If, however, one of the properties changes, the user is informed of the change and the update button will be enabled:
![image](https://user-images.githubusercontent.com/9608686/94803413-88a96c00-03e9-11eb-9db3-e300b71716d8.png)
