### PR TITLE
Fix updating progressbar positioning

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -284,6 +284,10 @@ export default class App extends Vue implements ErrorListener {
         padding: 0;
     }
 
+    .updating-snackbar-container .v-snack__wrapper {
+        display: block;
+    }
+
     .v-content__wrap .container--fluid {
         padding-top: 0 !important;
         padding-bottom: 0 !important;


### PR DESCRIPTION
Fixes the position of the progressbar in the application update snackbar.

Before: 
![image](https://user-images.githubusercontent.com/9608686/95748734-bf5d6d00-0c9a-11eb-82e0-3f10078bca1f.png)

After:
![image](https://user-images.githubusercontent.com/9608686/95748743-c4bab780-0c9a-11eb-93d8-d5f2d69dee51.png)
