### PR TITLE
Add version number to project

### DIFF
--- a/src/components/pages/HomePage.vue
+++ b/src/components/pages/HomePage.vue
@@ -85,6 +85,7 @@ import InvalidProjectException from "@/logic/filesystem/project/InvalidProjectEx
 import { Tooltip } from "unipept-web-components";
 import StaticDatabaseManager from "@/logic/communication/static/StaticDatabaseManager";
 import DemoProjectManager from "@/logic/filesystem/project/DemoProjectManager";
+import ProjectVersionMismatchException from "@/logic/exception/ProjectVersionMismatchException";
 
 const electron = require("electron");
 const { dialog } = electron.remote;
@@ -198,6 +199,11 @@ export default class HomePage extends Vue {
         } catch (err) {
             if (err instanceof InvalidProjectException) {
                 this.showError("This is not a valid Unipept project. Maybe you want to create a new project?");
+            } else if (err instanceof ProjectVersionMismatchException) {
+                this.showError(
+                    "This project was made with a newer version of the Unipept Desktop application. " +
+                    "Please update the application to continue."
+                );
             } else {
                 console.error(err);
                 this.showError(

--- a/src/db/schemas/schema_v1.sql
+++ b/src/db/schemas/schema_v1.sql
@@ -41,3 +41,7 @@ CREATE TABLE storage_metadata (
     PRIMARY KEY(assay_id),
     FOREIGN KEY(configuration_id) REFERENCES search_configuration(id)
 );
+
+CREATE TABLE database_metadata (
+    application_version TEXT NOT NULL
+);

--- a/src/logic/Utils.ts
+++ b/src/logic/Utils.ts
@@ -10,4 +10,26 @@ export default class Utils {
     static isMacOS(): boolean {
         return process.platform === "darwin";
     }
+
+    /**
+     * Compares two version strings.
+     *
+     * @param firstVersion
+     * @param secondVersion
+     * @return True if firstVersion is larger than secondVersion
+     */
+    static isVersionLargerThan(firstVersion: string, secondVersion: string): boolean {
+        const firstSplitted = firstVersion.split(".");
+        const secondSplitted = secondVersion.split(".");
+
+        for (let part = 0; part < firstSplitted.length; part++) {
+            if (firstSplitted[part] > secondSplitted[part]) {
+                return true;
+            } else if (firstSplitted[part] < secondSplitted[part]) {
+                return false;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/logic/exception/ProjectVersionMismatchException.ts
+++ b/src/logic/exception/ProjectVersionMismatchException.ts
@@ -1,0 +1,4 @@
+import { Exception } from "unipept-web-components";
+
+export default class ProjectVersionMismatchException extends Exception {}
+


### PR DESCRIPTION
This PR also adds the current DB schema version and the application version number to a project. An error is shown if users are trying to open projects that were made with a newer version of the application in an older version.

The DB-schema version number is also stored and will be used later on to migrate older project formats to new formats, if the schema changes with new versions of the application.

Screenshots:
![image](https://user-images.githubusercontent.com/9608686/97538020-01d3b900-19c0-11eb-8990-23b37aa672e3.png)
