### PR TITLE
Make sidebar scrollable

### DIFF
--- a/src/components/navigation-drawers/SingleAnalysisToolbar.vue
+++ b/src/components/navigation-drawers/SingleAnalysisToolbar.vue
@@ -1,19 +1,22 @@
 <template>
-    <div>
+    <div class="d-flex flex-column" style="min-height: 100%;">
         <div
             class="sample-list-placeholder"
             v-if="$store.getters.studies.length === 0">
             No studies present.
         </div>
-        <div
-            v-else
-            v-for="study of $store.getters.studies"
-            :key="study.getId()">
-            <study-item :study="study"></study-item>
+        <div v-else class="flex-grow-1">
+            <div
+                v-for="study of $store.getters.studies"
+                :key="study.getId()">
+                <study-item :study="study"></study-item>
+            </div>
         </div>
-        <v-btn class="select-sample-button" depressed color="primary" @click="createStudy()">
-            Create study
-        </v-btn>
+        <div class="text-center mt-4 mb-4">
+            <v-btn class="select-sample-button" depressed color="primary" @click="createStudy()">
+                Create study
+            </v-btn>
+        </div>
     </div>
 </template>
 
@@ -67,5 +70,15 @@ export default class SingleAnalysisToolbar extends Vue {
         position: relative;
         top: 16px;
         text-align: center;
+    }
+
+    .select-sample-button {
+
+        /*margin: 0 auto;*/
+        /*display: block !important;*/
+        /*position: sticky !important;*/
+        /*bottom: 72px;*/
+        /*left: 50%;*/
+        /*transform: translateX(-50%);*/
     }
 </style>

--- a/src/components/navigation-drawers/Toolbar.vue
+++ b/src/components/navigation-drawers/Toolbar.vue
@@ -161,15 +161,6 @@ export default class Toolbar extends Vue {
 </script>
 
 <style lang="less">
-    .select-sample-button {
-        margin: 0 auto;
-        display: block !important;
-        position: absolute !important;
-        bottom: 72px;
-        left: 50%;
-        transform: translateX(-50%);
-    }
-
     .toolbar-content {
         height: 100%;
         position: fixed;
@@ -192,9 +183,9 @@ export default class Toolbar extends Vue {
     }
 
     .toolbar-container {
-        position: relative;
-        top: 64px;
+        padding-top: 64px;
         height: 100%;
+        overflow-y: auto;
     }
 
     .container-after-titlebar .toolbar-container {


### PR DESCRIPTION
The project explorer did not show all assays and studies when too many assays or studies were created. This PR adds a scrollbar when this is the case, allowing the user to navigate to hidden items in the project explorer.