### PR TITLE
Add code signing action for Windows

### DIFF
--- a/.github/workflows/publish_linux.yml
+++ b/.github/workflows/publish_linux.yml
@@ -6,11 +6,8 @@ on:
       - master
 
 jobs:
-  publish:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest, ubuntu-latest]
+  release_linux:
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/publish_windows.yml
+++ b/.github/workflows/publish_windows.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           use_vue_cli: true
-          mac_certs: ${{ secrets.windows_certs }}
-          mac_certs_password: ${{ secrets.windows_certs_password }}
+          windows_certs: ${{ secrets.windows_certs }}
+          windows_certs_password: ${{ secrets.windows_certs_password }}
           release: true
+

--- a/.github/workflows/publish_windows.yml
+++ b/.github/workflows/publish_windows.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - feature/windows-signing
 
 jobs:
   release_windows:

--- a/.github/workflows/publish_windows.yml
+++ b/.github/workflows/publish_windows.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - feature/windows-signing
 
 jobs:
   release_windows:

--- a/.github/workflows/publish_windows.yml
+++ b/.github/workflows/publish_windows.yml
@@ -1,4 +1,4 @@
-name: Publish app on macOS
+name: Publish app on Windows
 
 on:
   push:
@@ -6,8 +6,8 @@ on:
       - master
 
 jobs:
-  release_macos:
-    runs-on: macos-latest
+  release_windows:
+    runs-on: windows-latest
 
     steps:
       - uses: actions/checkout@v1
@@ -17,9 +17,6 @@ jobs:
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           use_vue_cli: true
-          mac_certs: ${{ secrets.mac_certs }}
-          mac_certs_password: ${{ secrets.mac_certs_password }}
+          mac_certs: ${{ secrets.windows_certs }}
+          mac_certs_password: ${{ secrets.windows_certs_password }}
           release: true
-        env:
-          APPLEID: ${{ secrets.APPLEID }}
-          APPLEIDPASS: ${{ secrets.APPLEIDPASS }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unipept-desktop",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "author": "Unipept Team (Ghent University)",
   "description": "A desktop equivalent of unipept.ugent.be. This app aims at high-throughput analysis of metaproteomics samples.",


### PR DESCRIPTION
This PR introduces a new GitHub Action that publishes a _signed_ build for Windows.