### PR TITLE
Fix "exit app" button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unipept-desktop",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "author": "Unipept Team (Ghent University)",
   "description": "A desktop equivalent of unipept.ugent.be. This app aims at high-throughput analysis of metaproteomics samples.",

--- a/src/App.vue
+++ b/src/App.vue
@@ -54,7 +54,8 @@
                 <!-- Snackbar that's shown after the application has successfully been updated -->
                 <v-snackbar v-model="updatedSnackbar" :color="updatedColor" :timeout="-1">
                     {{ updateMessage }}
-                    <v-btn text dark @click="updatedSnackbar = false">Close app</v-btn>
+                    <v-btn text dark @click="updatedSnackbar = false">Dismiss</v-btn>
+                    <v-btn text dark @click="closeApplication">Exit app</v-btn>
                 </v-snackbar>
             </v-main>
         </v-app>
@@ -163,7 +164,6 @@ export default class App extends Vue implements ErrorListener {
         })
 
         await this.initConfiguration();
-        await this.setUpTitlebar();
     }
 
     public handleError(err: Error) {
@@ -181,22 +181,6 @@ export default class App extends Vue implements ErrorListener {
             ) / assays.length;
             electron.remote.BrowserWindow.getAllWindows()[0].setProgressBar(average);
         }
-    }
-
-    @Watch("useNativeTitlebar")
-    private setUpTitlebar() {
-        //   if (
-        //       Utils.isWindows() &&
-        //       !App.previouslyInitialized &&
-        //       this.titleBar == null && !this.$store.getters.useNativeTitlebar
-        //   ) {
-        //       this.titleBar = new Titlebar({
-        //           icon: require("./assets/icon.svg"),
-        //           backgroundColor: Color.fromHex("#004ba0")
-        //       });
-
-        //   }
-        //   App.previouslyInitialized = true;
     }
 
     /**

--- a/src/components/pages/HomePage.vue
+++ b/src/components/pages/HomePage.vue
@@ -54,7 +54,7 @@
             </v-row>
             <v-snackbar v-model="errorSnackbarVisible" bottom :timeout="-1" color="error">
                 {{ errorMessage }}
-                <v-btn dark text @click="errorSnackbarVisible = false">Close</v-btn>
+                <v-btn dark text @click="errorSnackbarVisible = false">Dismiss</v-btn>
             </v-snackbar>
             <v-dialog persistent v-model="downloadingDatabase" max-width="600px">
                 <v-card>


### PR DESCRIPTION
The "close app" button did not close the application. This PR fixes this and renames the button to "exit app"