### PR TITLE
Fix remember previous directory in FileDialog on Ubuntu

### DIFF
--- a/src/components/navigation-drawers/StudyItem.vue
+++ b/src/components/navigation-drawers/StudyItem.vue
@@ -161,6 +161,10 @@ export default class StudyItem extends Vue {
     // Keep track of the names of the assays that we are currently processing.
     private assaysInProgress: string[] = [];
 
+    // The previous directory that was used to load an assay from. 
+    // (Is required to open the file dialog in the same directory on Linux)
+    private previousDirectory: string = undefined;
+
     mounted() {
         this.onStudyChanged();
     }
@@ -253,12 +257,15 @@ export default class StudyItem extends Vue {
 
     private async createFromFile() {
         const chosenPath: Electron.OpenDialogReturnValue | undefined = await dialog.showOpenDialog({
-            properties: ["openFile"]
+            properties: ["openFile"],
+            defaultPath: this.previousDirectory
         });
 
         if (chosenPath && chosenPath["filePaths"] && chosenPath["filePaths"].length > 0) {
             let assayName = path.basename(chosenPath["filePaths"][0]).replace(/\.[^/.]+$/, "");
             assayName = this.generateUniqueAssayName(assayName);
+
+            this.previousDirectory = path.dirname(chosenPath["filePaths"][0]);
 
             this.assaysInProgress.push(assayName);
 


### PR DESCRIPTION
On Ubuntu (and maybe other Linux-based operating systems), the location from which the previous assay was selected is not remembered. Most of the time, multiple assays are selected from the same directory, which means that the user had to navigate to the same directory everytime an assay is selected. This PR fixes that behaviour on Linux (this is already the default behaviour on macOS and Windows).

(This issue was reported by @tivdnbos)