### PR TITLE
Fix positioning of create study button when project is empty

### DIFF
--- a/src/components/navigation-drawers/SingleAnalysisToolbar.vue
+++ b/src/components/navigation-drawers/SingleAnalysisToolbar.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="d-flex flex-column" style="min-height: 100%;">
         <div
-            class="sample-list-placeholder"
+            class="sample-list-placeholder flex-grow-1"
             v-if="$store.getters.studies.length === 0">
             No studies present.
         </div>


### PR DESCRIPTION
If the project is empty, the positioning of the "create study" button is wrong. This PR fixes the positioning of this button by always making sure that the list above the button takes up all available space.

Before:
![Screenshot 2020-11-23 at 14 17 50](https://user-images.githubusercontent.com/9608686/100196143-c06bf600-2ef8-11eb-9633-f82e7a1be0fa.png)

After:
<img width="1556" alt="Screenshot 2020-11-25 at 08 28 54" src="https://user-images.githubusercontent.com/9608686/100196151-c3ff7d00-2ef8-11eb-8254-8730fc791301.png">
