### PR TITLE
Fix reset selected assays when changing project

### DIFF
--- a/src/state/ComparativeStore.ts
+++ b/src/state/ComparativeStore.ts
@@ -36,6 +36,9 @@ const comparativeMutations: MutationTree<ComparativeState> = {
         if (id >= 0) {
             state.selectedAssays.splice(id, 1);
         }
+    },
+    RESET_SELECTED_ASSAYS(state: ComparativeState) {
+        state.selectedAssays.splice(0, state.selectedAssays.length);
     }
 }
 
@@ -46,6 +49,10 @@ const comparativeActions: ActionTree<ComparativeState, any> = {
 
     removeSelectedAssay(store: ActionContext<ComparativeState, any>, assay: Assay) {
         store.commit("REMOVE_SELECTED_ASSAY", assay);
+    },
+
+    resetSelectedAssays(store: ActionContext<ComparativeState, any>) {
+        store.commit("RESET_SELECTED_ASSAYS");
     }
 }
 

--- a/src/state/ProjectStore.ts
+++ b/src/state/ProjectStore.ts
@@ -86,9 +86,11 @@ const projectActions: ActionTree<ProjectState, any> = {
             Study[]
         ]
     ) {
+        await store.dispatch("resetSelectedAssays");
+
         // Make sure that all assays from the previously loaded project are gone.
         for (const assayData of store.rootGetters.assays) {
-            store.dispatch("removeAssay", assayData.assay);
+            await store.dispatch("removeAssay", assayData.assay);
         }
 
         if (!projectDirectory.endsWith("/")) {


### PR DESCRIPTION
Selected assays for comparative analysis are not reset when switching projects. This means that the selected assays from the previous project are still visible when a new project is opened. This PR fixes this issue.