### PR TITLE
Fix reset peptide list

### DIFF
--- a/src/components/navigation-drawers/StudyItem.vue
+++ b/src/components/navigation-drawers/StudyItem.vue
@@ -92,7 +92,7 @@
                 v-on:select-assay="onSelectAssay">
             </assay-item>
         </div>
-        <v-dialog v-model="showCreateAssayDialog" max-width="800" v-if="study">
+        <v-dialog v-model="showCreateAssayDialog" v-if="study && showCreateAssayDialog" max-width="800">
             <v-card>
                 <v-card-title>
                     Create assay
@@ -103,9 +103,9 @@
             </v-card>
         </v-dialog>
         <search-configuration-dialog
-                v-model="showSearchConfigDialog"
-                :assay="searchConfigAssay"
-                :callback="searchConfigCallback">
+            v-model="showSearchConfigDialog"
+            :assay="searchConfigAssay"
+            :callback="searchConfigCallback">
         </search-configuration-dialog>
         <confirm-deletion-dialog
             v-model="removeConfirmationActive"
@@ -187,7 +187,7 @@ export default class StudyItem extends Vue {
     // Keep track of the names of the assays that we are currently processing.
     private assaysInProgress: string[] = [];
 
-    // The previous directory that was used to load an assay from. 
+    // The previous directory that was used to load an assay from.
     // (Is required to open the file dialog in the same directory on Linux)
     private previousDirectory: string = undefined;
 


### PR DESCRIPTION
This PR introduces a fix for #99. By also adding the dialog-show condition to a `v-if` of the dialog, we force the recreation of this component every time it is rendered.