### PR TITLE
Bump UWC to v1.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "unipept-desktop",
-  "version": "0.6.4",
+  "version": "0.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -17218,9 +17218,9 @@
       }
     },
     "unipept-heatmap": {
-      "version": "2.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/unipept-heatmap/-/unipept-heatmap-2.0.0-beta.6.tgz",
-      "integrity": "sha512-Ob1x3UUYQWIYaq59F8xKjfMFefRZrN3J585AfSlGjTmGAsFiVnaSff53JQBfMt/pMmAk/nzM34WIKkDTZTQ04Q==",
+      "version": "2.0.0-beta.8",
+      "resolved": "https://registry.npmjs.org/unipept-heatmap/-/unipept-heatmap-2.0.0-beta.8.tgz",
+      "integrity": "sha512-MuJGueIAjF5IMyuZHL729L6bj91q4oJrFS6J80nq+7oDWgQyvfv85vvwrEKIb9TP79EP9Q2IuapJw+GU0U/QLQ==",
       "requires": {
         "@types/d3": "^5.16.0",
         "@types/sanitize-html": "^1.27.0",
@@ -17243,9 +17243,9 @@
       "integrity": "sha512-g9AM+44twT+qQpg4kHhupamMoBr4QscjqjQY8Pdk7cdWHvZs5HuIVTNtH44IbAtN08x9+U3BTT+lp+ZEJpaoFw=="
     },
     "unipept-web-components": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/unipept-web-components/-/unipept-web-components-1.3.1.tgz",
-      "integrity": "sha512-EhZIeWD5N8mInvyUxGkH35tGxMb1UjLNaTCVnSA3rg5o83loLP/xwJb3HvhnvfBZiXG+bh1W7sVS/1GxtZ3nAA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/unipept-web-components/-/unipept-web-components-1.3.2.tgz",
+      "integrity": "sha512-tdROhns8/DWoIpYWv7QEFzCHmCuGNpC92Y7JIyfvGY9Kz7LPNH0J998YTK7vRHJwtntPLaMrGUBHuGWjJl/GOw==",
       "requires": {
         "async": "^3.2.0",
         "axios": "^0.21.1",
@@ -17260,12 +17260,12 @@
         "jquery": "^3.4.1",
         "observable-fns": "^0.5.1",
         "shared-memory-datastructures": "0.1.9",
-        "unipept-heatmap": "^2.0.0-beta.6",
+        "unipept-heatmap": "^2.0.0-beta.8",
         "unipept-visualizations": "^1.7.3",
         "uuid": "^3.4.0",
         "vue": "^2.6.11",
         "vue-class-component": "^7.0.2",
-        "vue-fullscreen": "^2.1.5",
+        "vue-fullscreen": "^2.1.6",
         "vue-property-decorator": "^8.1.0",
         "vuetify": "^2.3.8",
         "vuex": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "node-abi": "^2.19.3",
     "regenerator-runtime": "^0.13.3",
     "shared-memory-datastructures": "0.1.8",
-    "unipept-web-components": "^1.3.1",
+    "unipept-web-components": "^1.3.2",
     "uuid": "^7.0.3",
     "vue": "^2.6.12",
     "vue-class-component": "^7.1.0",


### PR DESCRIPTION
This PR bumps the Unipept Web Components to version 1.3.2. This version brings the following changes:

* Fixed fullscreen support for visualizations (also added support for fullscreen heatmaps)
* Fixed padding around the TreeView in the AmountTable