### PR TITLE
Bump UWC to v1.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "node-abi": "^2.19.3",
         "regenerator-runtime": "^0.13.3",
         "shared-memory-datastructures": "0.1.8",
-        "unipept-web-components": "^1.4.0",
+        "unipept-web-components": "^1.4.1",
         "uuid": "^7.0.3",
         "vue": "^2.6.12",
         "vue-class-component": "^7.1.0",
@@ -20437,9 +20437,9 @@
       }
     },
     "node_modules/unipept-web-components": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/unipept-web-components/-/unipept-web-components-1.4.0.tgz",
-      "integrity": "sha512-/vUXJJBG/jBVOrOWprOKym9q9iipkc1rrjtsydTZYFvmoR/Do0jN4LQc9MSC5+eXMa7RBEvGpOmf0ATWC1Mv1w==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unipept-web-components/-/unipept-web-components-1.4.1.tgz",
+      "integrity": "sha512-6DSeY09nQ9Bq2Qr1U+V80XxOJdsxl1IBLOfAxKeymlpjkMcs7LdHrMg4ORxVfzcd5YxnqOOVnGr0ex4E+wzEug==",
       "dependencies": {
         "async": "^3.2.0",
         "axios": "^0.21.1",
@@ -40669,9 +40669,9 @@
       }
     },
     "unipept-web-components": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/unipept-web-components/-/unipept-web-components-1.4.0.tgz",
-      "integrity": "sha512-/vUXJJBG/jBVOrOWprOKym9q9iipkc1rrjtsydTZYFvmoR/Do0jN4LQc9MSC5+eXMa7RBEvGpOmf0ATWC1Mv1w==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unipept-web-components/-/unipept-web-components-1.4.1.tgz",
+      "integrity": "sha512-6DSeY09nQ9Bq2Qr1U+V80XxOJdsxl1IBLOfAxKeymlpjkMcs7LdHrMg4ORxVfzcd5YxnqOOVnGr0ex4E+wzEug==",
       "requires": {
         "async": "^3.2.0",
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "node-abi": "^2.19.3",
     "regenerator-runtime": "^0.13.3",
     "shared-memory-datastructures": "0.1.8",
-    "unipept-web-components": "^1.4.0",
+    "unipept-web-components": "^1.4.1",
     "uuid": "^7.0.3",
     "vue": "^2.6.12",
     "vue-class-component": "^7.1.0",


### PR DESCRIPTION
This PR bumps the Unipept Web Components used by this application to version 1.4.1, fixing the save button for some of the visualizations.