### PR TITLE
Fix bug causing large projects to crash on save

### DIFF
--- a/src/db/migrations/v1_to_v2.sql
+++ b/src/db/migrations/v1_to_v2.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS pept2data;

--- a/src/db/schemas/schema_v2.sql
+++ b/src/db/schemas/schema_v2.sql
@@ -1,0 +1,40 @@
+CREATE TABLE studies (
+                         id TEXT PRIMARY KEY,
+                         name TEXT NOT NULL
+);
+
+CREATE TABLE assays (
+                        id TEXT PRIMARY KEY,
+                        name TEXT NOT NULL,
+                        study_id TEXT NOT NULL,
+                        FOREIGN KEY(study_id) REFERENCES studies(id)
+);
+
+CREATE TABLE search_configuration (
+                                      id INTEGER PRIMARY KEY,
+                                      equate_il INT NOT NULL,
+                                      filter_duplicates INT NOT NULL,
+                                      missing_cleavage_handling INT NOT NULL
+);
+
+CREATE TABLE peptide_trust (
+                               assay_id TEXT NOT NULL,
+                               missed_peptides TEXT NOT NULL,
+                               matched_peptides INT NOT NULL,
+                               searched_peptides INT NOT NULL,
+                               PRIMARY KEY(assay_id)
+);
+
+CREATE TABLE storage_metadata (
+                                  assay_id TEXT NOT NULL,
+                                  configuration_id INT NOT NULL,
+                                  endpoint TEXT,
+                                  db_version TEXT,
+                                  analysis_date TEXT,
+                                  PRIMARY KEY(assay_id),
+                                  FOREIGN KEY(configuration_id) REFERENCES search_configuration(id)
+);
+
+CREATE TABLE database_metadata (
+    application_version TEXT NOT NULL
+);

--- a/src/logic/filesystem/assay/AssayFileSystemDestroyer.ts
+++ b/src/logic/filesystem/assay/AssayFileSystemDestroyer.ts
@@ -34,7 +34,6 @@ export default class AssayFileSystemDestroyer extends FileSystemAssayVisitor {
             const assayId = assay.getId();
 
             await this.dbManager.performQuery<void>((db: Database) => {
-                db.prepare("DELETE FROM pept2data WHERE `assay_id` = ?").run(assayId);
                 db.prepare("DELETE FROM peptide_trust WHERE `assay_id` = ?").run(assayId);
                 db.prepare("DELETE FROM storage_metadata WHERE `assay_id` = ?").run(assayId);
                 db.prepare("DELETE FROM assays WHERE `id` = ?").run(assayId);

--- a/src/logic/filesystem/database/DatabaseManager.ts
+++ b/src/logic/filesystem/database/DatabaseManager.ts
@@ -3,9 +3,12 @@ import async, { AsyncQueue } from "async";
 import DatabaseMigrator from "@/logic/filesystem/database/DatabaseMigrator";
 import DatabaseMigratorV0ToV1 from "@/logic/filesystem/database/DatabaseMigratorV0ToV1";
 import Schema from "@/logic/filesystem/database/Schema";
+import DatabaseMigratorV1ToV2 from "@/logic/filesystem/database/DatabaseMigratorV1ToV2";
 
 const electron = require("electron");
 const app = electron.remote.app;
+
+import path from "path";
 
 export default class DatabaseManager {
     // Reading and writing large assays to and from the database can easily take longer than 5 seconds, causing
@@ -23,7 +26,8 @@ export default class DatabaseManager {
 
     // Maps each schema index onto the db-migrator that can be used to update the db to the next schema version.
     private readonly migrations: (() => DatabaseMigrator)[] = [
-        () => new DatabaseMigratorV0ToV1()
+        () => new DatabaseMigratorV0ToV1(),
+        () => new DatabaseMigratorV1ToV2(path.dirname(this.dbLocation))
     ];
 
     constructor(

--- a/src/logic/filesystem/database/DatabaseMigratorV1ToV2.ts
+++ b/src/logic/filesystem/database/DatabaseMigratorV1ToV2.ts
@@ -1,0 +1,46 @@
+import DatabaseMigrator from "@/logic/filesystem/database/DatabaseMigrator";
+import { Database } from "better-sqlite3";
+import v1_to_v2 from "raw-loader!@/db/migrations/v1_to_v2.sql";
+import path from "path";
+import { store } from "@/main";
+import mkdirp from "mkdirp";
+import fs from "fs";
+
+const electron = require("electron");
+const app = electron.remote.app;
+
+/**
+ * This migrator updates the current database from schema version 0 to version 1.
+ *
+ * Changes between these schema versions:
+ * - Added new table "database_metadata", which keeps track of the current application version.
+ */
+export default class DatabaseMigratorV1ToV2 implements DatabaseMigrator {
+    constructor(private readonly projectLocation: string) {}
+
+    public upgrade(database: Database): void {
+        this.migrateBuffers(database);
+        // Read in the buffers from the database and write these to a file.
+        database.exec(v1_to_v2);
+    }
+
+    private migrateBuffers(database: Database): void {
+        const rows = database.prepare("SELECT * FROM pept2data").all();
+        for (const row of rows) {
+            const indexBuffer = row.index_buffer;
+            const dataBuffer = row.data_buffer;
+            const assayId = row.assay_id;
+
+            // Write each of these buffers to the project directory according to the new format.
+            const bufferDirectory = path.join(this.projectLocation, ".buffers");
+            mkdirp.sync(bufferDirectory);
+
+            const indexBufferPath = path.join(bufferDirectory, assayId + ".index");
+            const dataBufferPath = path.join(bufferDirectory, assayId + ".data");
+
+            // Write new version of this file's buffer to file
+            fs.writeFileSync(indexBufferPath, indexBuffer);
+            fs.writeFileSync(dataBufferPath, dataBuffer);
+        }
+    }
+}

--- a/src/logic/filesystem/database/Schema.ts
+++ b/src/logic/filesystem/database/Schema.ts
@@ -1,6 +1,6 @@
-import schema_v1 from "raw-loader!@/db/schemas/schema_v1.sql";
+import schema_v2 from "raw-loader!@/db/schemas/schema_v2.sql";
 
 export default class Schema {
-    public static LATEST_VERSION: number = 1;
-    public static LATEST_SCHEMA: string = schema_v1;
+    public static LATEST_VERSION: number = 2;
+    public static LATEST_SCHEMA: string = schema_v2;
 }

--- a/src/logic/filesystem/project/FileSystemWatcher.ts
+++ b/src/logic/filesystem/project/FileSystemWatcher.ts
@@ -29,7 +29,7 @@ export default class FileSystemWatcher {
         this.watcher = chokidar.watch(store.getters.projectLocation, {
             ignoreInitial: true,
             // Ignore hidden files and metadata changes
-            ignored: /^\..*$|metadata.sqlite/,
+            ignored: /^\..*$|metadata.sqlite|\.buffers/,
             awaitWriteFinish: {
                 stabilityThreshold: 1000,
                 pollInterval: 100

--- a/src/logic/filesystem/project/ProjectManager.ts
+++ b/src/logic/filesystem/project/ProjectManager.ts
@@ -52,7 +52,7 @@ export default class ProjectManager  {
 
         // Check all subdirectories of the given project and try to load the studies.
         const subDirectories: string[] = fs.readdirSync(projectLocation, { withFileTypes: true })
-            .filter(dirEntry => dirEntry.isDirectory())
+            .filter(dirEntry => dirEntry.isDirectory() && dirEntry.name !== ".buffers")
             .map(dirEntry => dirEntry.name);
 
         const studies = [];


### PR DESCRIPTION
This PR fixes a bug that caused the application to crash when large assay's are being analysed. Instead of directly storing a binary representation of the application's state in the SQLite-database, I decided to move this information to a separate file in each project.