### PR TITLE
Update base URL to api.unipept.ugent.be

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,24 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+preferred-citation:
+  type: article
+  authors:
+  - family-names: "Verschaffelt"
+    given-names: "Pieter"
+  - family-names: "Van Den Bossche"
+    given-names: "Tim"
+  - family-names: "Martens"
+    given-names: "Lennart"
+  - family-names: "Dawyndt"
+    given-names: "Peter"
+  - family-names: "Mesuere"
+    given-names: "Bart"
+    orcid: "https://orcid.org/0000-0003-0610-3441"
+  doi: "10.1021/acs.jproteome.0c00855"
+  journal: "Journal of Proteome Research"
+  start: 2005
+  end: 2009
+  title: "Unipept Desktop: A Faster, More Powerful Metaproteomics Results Analysis Tool"
+  issue: 4
+  volume: 20
+  year: 2021

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "unipept-desktop",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.2.0",
+      "version": "1.2.1",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/preset-env": "^7.6.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -194,6 +194,7 @@ export default class App extends Vue implements ErrorListener {
         try {
             let config: Configuration = await configurationManager.readConfiguration();
             NetworkConfiguration.BASE_URL = config.apiSource;
+            // Make sure that the old Unipept URL is no longer being used...
             if (NetworkConfiguration.BASE_URL === "https://unipept.ugent.be") {
                 NetworkConfiguration.BASE_URL = "https://api.unipept.ugent.be";
             }

--- a/src/App.vue
+++ b/src/App.vue
@@ -194,6 +194,9 @@ export default class App extends Vue implements ErrorListener {
         try {
             let config: Configuration = await configurationManager.readConfiguration();
             NetworkConfiguration.BASE_URL = config.apiSource;
+            if (NetworkConfiguration.BASE_URL === "https://unipept.ugent.be") {
+                NetworkConfiguration.BASE_URL = "https://api.unipept.ugent.be";
+            }
             NetworkConfiguration.PARALLEL_API_REQUESTS = config.maxParallelRequests;
             QueueManager.initializeQueue(config.maxLongRunningTasks);
         } catch (err) {

--- a/src/logic/configuration/ConfigurationManager.ts
+++ b/src/logic/configuration/ConfigurationManager.ts
@@ -11,10 +11,10 @@ export default class ConfigurationManager {
     // This is the default configuration object that's used as a fallback for inconsistent/inavailable configuration
     // values.
     private static readonly DEFAULT_CONFIG: Configuration = {
-        apiSource: "https://unipept.ugent.be",
+        apiSource: "https://api.unipept.ugent.be",
         useNativeTitlebar: false,
         maxLongRunningTasks: 8,
-        maxParallelRequests: 5
+        maxParallelRequests: 2
     };
     // Reference to the last configuration that was returned by this manager. Can be used to update the current
     // configuration and write the changes to disk (without having to read it again).


### PR DESCRIPTION
This PR updates the default base URL that's used for all API-requests to api.unipept.ugent.be instead of unipept.ugent.be