### PR TITLE
Improve information about current filtering state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "unipept-desktop",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.2.3",
+      "version": "1.2.4",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/preset-env": "^7.6.0",
@@ -39,7 +39,7 @@
         "node-abi": "^2.19.3",
         "regenerator-runtime": "^0.13.3",
         "shared-memory-datastructures": "0.1.9",
-        "unipept-web-components": "^1.5.1",
+        "unipept-web-components": "^1.5.2",
         "uuid": "^7.0.3",
         "vue": "^2.6.12",
         "vue-class-component": "^7.1.0",
@@ -1502,198 +1502,225 @@
       }
     },
     "node_modules/@types/d3": {
-      "version": "6.5.0",
-      "integrity": "sha512-jVKWUprtDUVybTV73X1z2aSR5/McX+gHv7duAB6RhXksB+hlvzd6MJkRz299n2xKzOgA4fdGJdXrwIaIfaFtZw==",
+      "version": "6.7.5",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-6.7.5.tgz",
+      "integrity": "sha512-TUZ6zuT/KIvbHSv81kwAiO5gG5aTuoiLGnWR/KxHJ15Idy/xmGUXaaF5zMG+UMIsndcGlSHTmrvwRgdvZlNKaA==",
       "dependencies": {
-        "@types/d3-array": "*",
-        "@types/d3-axis": "*",
-        "@types/d3-brush": "*",
-        "@types/d3-chord": "*",
-        "@types/d3-color": "*",
-        "@types/d3-contour": "*",
-        "@types/d3-delaunay": "*",
-        "@types/d3-dispatch": "*",
-        "@types/d3-drag": "*",
-        "@types/d3-dsv": "*",
-        "@types/d3-ease": "*",
-        "@types/d3-fetch": "*",
-        "@types/d3-force": "*",
-        "@types/d3-format": "*",
-        "@types/d3-geo": "*",
-        "@types/d3-hierarchy": "*",
-        "@types/d3-interpolate": "*",
-        "@types/d3-path": "*",
-        "@types/d3-polygon": "*",
-        "@types/d3-quadtree": "*",
-        "@types/d3-random": "*",
-        "@types/d3-scale": "*",
-        "@types/d3-scale-chromatic": "*",
-        "@types/d3-selection": "*",
-        "@types/d3-shape": "*",
-        "@types/d3-time": "*",
-        "@types/d3-time-format": "*",
-        "@types/d3-timer": "*",
-        "@types/d3-transition": "*",
-        "@types/d3-zoom": "*"
+        "@types/d3-array": "^2",
+        "@types/d3-axis": "^2",
+        "@types/d3-brush": "^2",
+        "@types/d3-chord": "^2",
+        "@types/d3-color": "^2",
+        "@types/d3-contour": "^2",
+        "@types/d3-delaunay": "^5",
+        "@types/d3-dispatch": "^2",
+        "@types/d3-drag": "^2",
+        "@types/d3-dsv": "^2",
+        "@types/d3-ease": "^2",
+        "@types/d3-fetch": "^2",
+        "@types/d3-force": "^2",
+        "@types/d3-format": "^2",
+        "@types/d3-geo": "^2",
+        "@types/d3-hierarchy": "^2",
+        "@types/d3-interpolate": "^2",
+        "@types/d3-path": "^2",
+        "@types/d3-polygon": "^2",
+        "@types/d3-quadtree": "^2",
+        "@types/d3-random": "^2",
+        "@types/d3-scale": "^3",
+        "@types/d3-scale-chromatic": "^2",
+        "@types/d3-selection": "^2",
+        "@types/d3-shape": "^2",
+        "@types/d3-time": "^2",
+        "@types/d3-time-format": "^3",
+        "@types/d3-timer": "^2",
+        "@types/d3-transition": "^2",
+        "@types/d3-zoom": "^2"
       }
     },
     "node_modules/@types/d3-array": {
-      "version": "2.11.0",
-      "integrity": "sha512-Av6SK7wIOA7sXp32+wBkCwWQI5etz/WEOmJX3fQ9+tajhUVuSU2c7NScjXn+dbbcWizKIaGLIqMGQkwCQ3KTeQ=="
+      "version": "2.12.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-2.12.3.tgz",
+      "integrity": "sha512-hN879HLPTVqZV3FQEXy7ptt083UXwguNbnxdTGzVW4y4KjX5uyNKljrQixZcSJfLyFirbpUokxpXtvR+N5+KIg=="
     },
     "node_modules/@types/d3-axis": {
-      "version": "2.0.0",
-      "integrity": "sha512-gUdlEwGBLl3tXGiBnBNmNzph9W3bCfa4tBgWZD60Z1eDQKTY4zyCAcZ3LksignGfKawYatmDYcBdjJ5h/54sqA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-2.1.3.tgz",
+      "integrity": "sha512-QjXjwZ0xzyrW2ndkmkb09ErgWDEYtbLBKGui73QLMFm3woqWpxptfD5Y7vqQdybMcu7WEbjZ5q+w2w5+uh2IjA==",
       "dependencies": {
-        "@types/d3-selection": "*"
+        "@types/d3-selection": "^2"
       }
     },
     "node_modules/@types/d3-brush": {
-      "version": "2.1.0",
-      "integrity": "sha512-rLQqxQeXWF4ArXi81GlV8HBNwJw9EDpz0jcWvvzv548EDE4tXrayBTOHYi/8Q4FZ/Df8PGXFzxpAVQmJMjOtvQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-2.1.2.tgz",
+      "integrity": "sha512-DnZmjdK1ycX1CMiW9r5E3xSf1tL+bp3yob1ON8bf0xB0/odfmGXeYOTafU+2SmU1F0/dvcqaO4SMjw62onOu6A==",
       "dependencies": {
-        "@types/d3-selection": "*"
+        "@types/d3-selection": "^2"
       }
     },
     "node_modules/@types/d3-chord": {
-      "version": "2.0.1",
-      "integrity": "sha512-mqGww8qDtGZRnDsFizzobAVizd85hgaYNEri095ZI7/aYtW7hxa9a20enwuoVTWm0YqdCtLPoyV9ZPYgfyaTZw=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-2.0.3.tgz",
+      "integrity": "sha512-koIqSNQLPRQPXt7c55hgRF6Lr9Ps72r1+Biv55jdYR+SHJ463MsB2lp4ktzttFNmrQw/9yWthf/OmSUj5dNXKw=="
     },
     "node_modules/@types/d3-color": {
-      "version": "2.0.1",
-      "integrity": "sha512-u7LTCL7RnaavFSmob2rIAJLNwu50i6gFwY9cHFr80BrQURYQBRkJ+Yv47nA3Fm7FeRhdWTiVTeqvSeOuMAOzBQ=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-2.0.3.tgz",
+      "integrity": "sha512-+0EtEjBfKEDtH9Rk3u3kLOUXM5F+iZK+WvASPb0MhIZl8J8NUvGeZRwKCXl+P3HkYx5TdU4YtcibpqHkSR9n7w=="
     },
     "node_modules/@types/d3-contour": {
-      "version": "2.0.0",
-      "integrity": "sha512-PS9UO6zBQqwHXsocbpdzZFONgK1oRUgWtjjh/iz2vM06KaXLInLiKZ9e3OLBRerc1cU2uJYpO+8zOnb6frvCGQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-2.0.4.tgz",
+      "integrity": "sha512-WMac1xV/mXAgkgr5dUvzsBV5OrgNZDBDpJk9s3v2SadTqGgDRirKABb2Ek2H1pFlYVH4Oly9XJGnuzxKDduqWA==",
       "dependencies": {
-        "@types/d3-array": "*",
+        "@types/d3-array": "^2",
         "@types/geojson": "*"
       }
     },
     "node_modules/@types/d3-delaunay": {
-      "version": "5.3.0",
-      "integrity": "sha512-gJYcGxLu0xDZPccbUe32OUpeaNtd1Lz0NYJtko6ZLMyG2euF4pBzrsQXms67LHZCDFzzszw+dMhSL/QAML3bXw=="
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-5.3.1.tgz",
+      "integrity": "sha512-F6itHi2DxdatHil1rJ2yEFUNhejj8+0Acd55LZ6Ggwbdoks0+DxVY2cawNj16sjCBiWvubVlh6eBMVsYRNGLew=="
     },
     "node_modules/@types/d3-dispatch": {
-      "version": "2.0.0",
-      "integrity": "sha512-Sh0KW6z/d7uxssD7K4s4uCSzlEG/+SP+U47q098NVdOfFvUKNTvKAIV4XqjxsUuhE/854ARAREHOxkr9gQOCyg=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-2.0.1.tgz",
+      "integrity": "sha512-eT2K8uG3rXkmRiCpPn0rNrekuSLdBfV83vbTvfZliA5K7dbeaqWS/CBHtJ9SQoF8aDTsWSY4A0RU67U/HcKdJQ=="
     },
     "node_modules/@types/d3-drag": {
-      "version": "2.0.0",
-      "integrity": "sha512-VaUJPjbMnDn02tcRqsHLRAX5VjcRIzCjBfeXTLGe6QjMn5JccB5Cz4ztMRXMJfkbC45ovgJFWuj6DHvWMX1thA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-2.0.2.tgz",
+      "integrity": "sha512-m9USoFaTgVw2mmE7vLjWTApT9dMxMlql/dl3Gj503x+1a2n6K455iDWydqy2dfCpkUBCoF82yRGDgcSk9FUEyQ==",
       "dependencies": {
-        "@types/d3-selection": "*"
+        "@types/d3-selection": "^2"
       }
     },
     "node_modules/@types/d3-dsv": {
-      "version": "2.0.1",
-      "integrity": "sha512-wovgiG9Mgkr/SZ/m/c0m+RwrIT4ozsuCWeLxJyoObDWsie2DeQT4wzMdHZPR9Ya5oZLQT3w3uSl0NehG0+0dCA=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-2.0.2.tgz",
+      "integrity": "sha512-T4aL2ZzaILkLGKbxssipYVRs8334PSR9FQzTGftZbc3jIPGkiXXS7qUCh8/q8UWFzxBZQ92dvR0v7+AM9wL2PA=="
     },
     "node_modules/@types/d3-ease": {
-      "version": "2.0.0",
-      "integrity": "sha512-6aZrTyX5LG+ptofVHf+gTsThLRY1nhLotJjgY4drYqk1OkJMu2UvuoZRlPw2fffjRHeYepue3/fxTufqKKmvsA=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-2.0.2.tgz",
+      "integrity": "sha512-29Y73Tg6o6aL+3/S/kEun84m5BO4bjRNau6pMWv9N9rZHcJv/O/07mW6EjqxrePZZS64fj0wiB5LMHr4Jzf3eQ=="
     },
     "node_modules/@types/d3-fetch": {
-      "version": "2.0.0",
-      "integrity": "sha512-WnLepGtxepFfXRdPI8I5FTgNiHn9p4vMTTqaNCzJJfAswXx0rOY2jjeolzEU063em3iJmGZ+U79InnEeFOrCRw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-2.0.2.tgz",
+      "integrity": "sha512-sllsCSWrNdSvzOJWN5RnxkmtvW9pCttONGajSxHX9FUQ9kOkGE391xlz6VDBdZxLnpwjp3I+mipbwsaCjq4m5A==",
       "dependencies": {
-        "@types/d3-dsv": "*"
+        "@types/d3-dsv": "^2"
       }
     },
     "node_modules/@types/d3-force": {
-      "version": "2.1.1",
-      "integrity": "sha512-3r+CQv2K/uDTAVg0DGxsbBjV02vgOxb8RhPIv3gd6cp3pdPAZ7wEXpDjUZSoqycAQLSDOxG/AZ54Vx6YXZSbmQ=="
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-2.1.4.tgz",
+      "integrity": "sha512-1XVRc2QbeUSL1FRVE53Irdz7jY+drTwESHIMVirCwkAAMB/yVC8ezAfx/1Alq0t0uOnphoyhRle1ht5CuPgSJQ=="
     },
     "node_modules/@types/d3-format": {
-      "version": "2.0.0",
-      "integrity": "sha512-uagdkftxnGkO4pZw5jEYOM5ZnZOEsh7z8j11Qxk85UkB2RzfUUxRl7R9VvvJZHwKn8l+x+rpS77Nusq7FkFmIg=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-2.0.2.tgz",
+      "integrity": "sha512-OhQPuTeeMhD9A0Ksqo4q1S9Z1Q57O/t4tTPBxBQxRB4IERnxeoEYLPe72fA/GYpPSUrfKZVOgLHidkxwbzLdJA=="
     },
     "node_modules/@types/d3-geo": {
-      "version": "2.0.0",
-      "integrity": "sha512-DHHgYXW36lnAEQMYU2udKVOxxljHrn2EdOINeSC9jWCAXwOnGn7A19B8sNsHqgpu4F7O2bSD7//cqBXD3W0Deg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-2.0.3.tgz",
+      "integrity": "sha512-kFwLEMXq1mGJ2Eho7KrOUYvLcc2YTDeKj+kTFt87JlEbRQ0rgo8ZENNb5vTYmZrJ2xL/vVM5M7yqVZGOPH2JFg==",
       "dependencies": {
         "@types/geojson": "*"
       }
     },
     "node_modules/@types/d3-hierarchy": {
-      "version": "2.0.0",
-      "integrity": "sha512-YxdskUvwzqggpnSnDQj4KVkicgjpkgXn/g/9M9iGsiToLS3nG6Ytjo1FoYhYVAAElV/fJBGVL3cQ9Hb7tcv+lw=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-2.0.2.tgz",
+      "integrity": "sha512-6PlBRwbjUPPt0ZFq/HTUyOAdOF3p73EUYots74lHMUyAVtdFSOS/hAeNXtEIM9i7qRDntuIblXxHGUMb9MuNRA=="
     },
     "node_modules/@types/d3-interpolate": {
-      "version": "2.0.0",
-      "integrity": "sha512-Wt1v2zTlEN8dSx8hhx6MoOhWQgTkz0Ukj7owAEIOF2QtI0e219paFX9rf/SLOr/UExWb1TcUzatU8zWwFby6gg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-2.0.2.tgz",
+      "integrity": "sha512-lElyqlUfIPyWG/cD475vl6msPL4aMU7eJvx1//Q177L8mdXoVPFl1djIESF2FKnc0NyaHvQlJpWwKJYwAhUoCw==",
       "dependencies": {
-        "@types/d3-color": "*"
+        "@types/d3-color": "^2"
       }
     },
     "node_modules/@types/d3-path": {
-      "version": "2.0.0",
-      "integrity": "sha512-tXcR/9OtDdeCIsyl6eTNHC3XOAOdyc6ceF3QGBXOd9jTcK+ex/ecr00p9L9362e/op3UEPpxrToi1FHrtTSj7Q=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-2.0.2.tgz",
+      "integrity": "sha512-3YHpvDw9LzONaJzejXLOwZ3LqwwkoXb9LI2YN7Hbd6pkGo5nIlJ09ul4bQhBN4hQZJKmUpX8HkVqbzgUKY48cg=="
     },
     "node_modules/@types/d3-polygon": {
-      "version": "2.0.0",
-      "integrity": "sha512-fISnMd8ePED1G4aa4V974Jmt+ajHSgPoxMa2D0ULxMybpx0Vw4WEzhQEaMIrL3hM8HVRcKTx669I+dTy/4PhAw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-2.0.1.tgz",
+      "integrity": "sha512-X3XTIwBxlzRIWe4yaD1KsmcfItjSPLTGL04QDyP08jyHDVsnz3+NZJMwtD4vCaTAVpGSjbqS+jrBo8cO2V/xMA=="
     },
     "node_modules/@types/d3-quadtree": {
-      "version": "2.0.0",
-      "integrity": "sha512-YZuJuGBnijD0H+98xMJD4oZXgv/umPXy5deu3IimYTPGH3Kr8Th6iQUff0/6S80oNBD7KtOuIHwHUCymUiRoeQ=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-2.0.2.tgz",
+      "integrity": "sha512-KgWL4jlz8QJJZX01E4HKXJ9FLU94RTuObsAYqsPp8YOAcYDmEgJIQJ+ojZcnKUAnrUb78ik8JBKWas5XZPqJnQ=="
     },
     "node_modules/@types/d3-random": {
-      "version": "2.2.0",
-      "integrity": "sha512-Hjfj9m68NmYZzushzEG7etPvKH/nj9b9s9+qtkNG3/dbRBjQZQg1XS6nRuHJcCASTjxXlyXZnKu2gDxyQIIu9A=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-2.2.1.tgz",
+      "integrity": "sha512-5vvxn6//poNeOxt1ZwC7QU//dG9QqABjy1T7fP/xmFHY95GnaOw3yABf29hiu5SR1Oo34XcpyHFbzod+vemQjA=="
     },
     "node_modules/@types/d3-scale": {
-      "version": "3.2.2",
-      "integrity": "sha512-qpQe8G02tzUwt9sdWX1h8A/W0Q1+N48wMnYXVOkrzeLUkCfvzJYV9Ee3aORCS4dN4ONRLFmMvaXdziQ29XGLjQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-3.3.2.tgz",
+      "integrity": "sha512-gGqr7x1ost9px3FvIfUMi5XA/F/yAf4UkUDtdQhpH92XCT0Oa7zkkRzY61gPVJq+DxpHn/btouw5ohWkbBsCzQ==",
       "dependencies": {
-        "@types/d3-time": "*"
+        "@types/d3-time": "^2"
       }
     },
     "node_modules/@types/d3-scale-chromatic": {
-      "version": "2.0.0",
-      "integrity": "sha512-Y62+2clOwZoKua84Ha0xU77w7lePiaBoTjXugT4l8Rd5LAk+Mn/ZDtrgs087a+B5uJ3jYUHHtKw5nuEzp0WBHw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-2.0.1.tgz",
+      "integrity": "sha512-3EuZlbPu+pvclZcb1DhlymTWT2W+lYsRKBjvkH2ojDbCWDYavifqu1vYX9WGzlPgCgcS4Alhk1+zapXbGEGylQ=="
     },
     "node_modules/@types/d3-selection": {
-      "version": "2.0.0",
-      "integrity": "sha512-EF0lWZ4tg7oDFg4YQFlbOU3936e3a9UmoQ2IXlBy1+cv2c2Pv7knhKUzGlH5Hq2sF/KeDTH1amiRPey2rrLMQA=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-2.0.1.tgz",
+      "integrity": "sha512-3mhtPnGE+c71rl/T5HMy+ykg7migAZ4T6gzU0HxpgBFKcasBrSnwRbYV1/UZR6o5fkpySxhWxAhd7yhjj8jL7g=="
     },
     "node_modules/@types/d3-shape": {
-      "version": "2.0.0",
-      "integrity": "sha512-NLzD02m5PiD1KLEDjLN+MtqEcFYn4ZL9+Rqc9ZwARK1cpKZXd91zBETbe6wpBB6Ia0D0VZbpmbW3+BsGPGnCpA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-2.1.3.tgz",
+      "integrity": "sha512-HAhCel3wP93kh4/rq+7atLdybcESZ5bRHDEZUojClyZWsRuEMo3A52NGYJSh48SxfxEU6RZIVbZL2YFZ2OAlzQ==",
       "dependencies": {
-        "@types/d3-path": "^1"
+        "@types/d3-path": "^2"
       }
     },
-    "node_modules/@types/d3-shape/node_modules/@types/d3-path": {
-      "version": "1.0.9",
-      "integrity": "sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ=="
-    },
     "node_modules/@types/d3-time": {
-      "version": "2.0.0",
-      "integrity": "sha512-Abz8bTzy8UWDeYs9pCa3D37i29EWDjNTjemdk0ei1ApYVNqulYlGUKip/jLOpogkPSsPz/GvZCYiC7MFlEk0iQ=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-2.1.1.tgz",
+      "integrity": "sha512-9MVYlmIgmRR31C5b4FVSWtuMmBHh2mOWQYfl7XAYOa8dsnb7iEmUmRSWSFgXFtkjxO65d7hTUHQC+RhR/9IWFg=="
     },
     "node_modules/@types/d3-time-format": {
-      "version": "3.0.0",
-      "integrity": "sha512-UpLg1mn/8PLyjr+J/JwdQJM/GzysMvv2CS8y+WYAL5K0+wbvXv/pPSLEfdNaprCZsGcXTxPsFMy8QtkYv9ueew=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-3.0.1.tgz",
+      "integrity": "sha512-5GIimz5IqaRsdnxs4YlyTZPwAMfALu/wA4jqSiuqgdbCxUZ2WjrnwANqOtoBJQgeaUTdYNfALJO0Yb0YrDqduA=="
     },
     "node_modules/@types/d3-timer": {
-      "version": "2.0.0",
-      "integrity": "sha512-l6stHr1VD1BWlW6u3pxrjLtJfpPZq9I3XmKIQtq7zHM/s6fwEtI1Yn6Sr5/jQTrUDCC5jkS6gWqlFGCDArDqNg=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-2.0.1.tgz",
+      "integrity": "sha512-TF8aoF5cHcLO7W7403blM7L1T+6NF3XMyN3fxyUolq2uOcFeicG/khQg/dGxiCJWoAcmYulYN7LYSRKO54IXaA=="
     },
     "node_modules/@types/d3-transition": {
-      "version": "2.0.0",
-      "integrity": "sha512-UJDzI98utcZQUJt3uIit/Ho0/eBIANzrWJrTmi4+TaKIyWL2iCu7ShP0o4QajCskhyjOA7C8+4CE3b1YirTzEQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-2.0.2.tgz",
+      "integrity": "sha512-376TICEykdXOEA9uUIYpjshEkxfGwCPnkHUl8+6gphzKbf5NMnUhKT7wR59Yxrd9wtJ/rmE3SVLx6/8w4eY6Zg==",
       "dependencies": {
-        "@types/d3-selection": "*"
+        "@types/d3-selection": "^2"
       }
     },
     "node_modules/@types/d3-zoom": {
-      "version": "2.0.1",
-      "integrity": "sha512-FuiGLfaHmp84b9wsj0dG03E/aJl5k98OLnJ2/5p7bQOHEpWqR+z5WCoWYMAbdGxaca7VNd9tCT5i6AJnpauNTQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-2.0.3.tgz",
+      "integrity": "sha512-9X9uDYKk2U8w775OHj36s9Q7GkNAnJKGw6+sbkP5DpHSjELwKvTGzEK6+IISYfLpJRL/V3mRXMhgDnnJ5LkwJg==",
       "dependencies": {
-        "@types/d3-interpolate": "*",
-        "@types/d3-selection": "*"
+        "@types/d3-interpolate": "^2",
+        "@types/d3-selection": "^2"
       }
     },
     "node_modules/@types/debug": {
@@ -1733,8 +1760,9 @@
       }
     },
     "node_modules/@types/geojson": {
-      "version": "7946.0.7",
-      "integrity": "sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ=="
+      "version": "7946.0.8",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
+      "integrity": "sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA=="
     },
     "node_modules/@types/glob": {
       "version": "7.1.3",
@@ -1977,11 +2005,12 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "4.24.0",
-      "integrity": "sha512-9+WYJGDnuC9VtYLqBhcSuM7du75fyCS/ypC8c5g7Sdw7pGL4NDTbeH38eJPfzIydCHZDoOgjloxSAA3+4l/zsA==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
+      "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
       "dependencies": {
-        "@typescript-eslint/types": "4.24.0",
-        "@typescript-eslint/visitor-keys": "4.24.0"
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/visitor-keys": "4.33.0"
       },
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -1992,8 +2021,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "4.24.0",
-      "integrity": "sha512-tkZUBgDQKdvfs8L47LaqxojKDE+mIUmOzdz7r+u+U54l3GDkTpEbQ1Jp3cNqqAU9vMUCBA1fitsIhm7yN0vx9Q==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
+      "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
       },
@@ -2023,10 +2053,11 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "4.24.0",
-      "integrity": "sha512-4ox1sjmGHIxjEDBnMCtWFFhErXtKA1Ec0sBpuz0fqf3P+g3JFGyTxxbF06byw0FRsPnnbq44cKivH7Ks1/0s6g==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
+      "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
       "dependencies": {
-        "@typescript-eslint/types": "4.24.0",
+        "@typescript-eslint/types": "4.33.0",
         "eslint-visitor-keys": "^2.0.0"
       },
       "engines": {
@@ -2039,6 +2070,7 @@
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
       "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
       "engines": {
         "node": ">=10"
@@ -7911,6 +7943,7 @@
     },
     "node_modules/d3": {
       "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-6.7.0.tgz",
       "integrity": "sha512-hNHRhe+yCDLUG6Q2LwvR/WdNFPOJQ5VWqsJcwIYVeI401+d2/rrCjxSXkiAdIlpx7/73eApFB4Olsmh3YN7a6g==",
       "dependencies": {
         "d3-array": "2",
@@ -7947,6 +7980,7 @@
     },
     "node_modules/d3-array": {
       "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
       "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
       "dependencies": {
         "internmap": "^1.0.0"
@@ -7954,10 +7988,12 @@
     },
     "node_modules/d3-axis": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-2.1.0.tgz",
       "integrity": "sha512-z/G2TQMyuf0X3qP+Mh+2PimoJD41VOCjViJzT0BHeL/+JQAofkiWZbWxlwFGb1N8EN+Cl/CW+MUKbVzr1689Cw=="
     },
     "node_modules/d3-brush": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-2.1.0.tgz",
       "integrity": "sha512-cHLLAFatBATyIKqZOkk/mDHUbzne2B3ZwxkzMHvFTCZCmLaXDpZRihQSn8UNXTkGD/3lb/W2sQz0etAftmHMJQ==",
       "dependencies": {
         "d3-dispatch": "1 - 2",
@@ -7969,6 +8005,7 @@
     },
     "node_modules/d3-chord": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-2.0.0.tgz",
       "integrity": "sha512-D5PZb7EDsRNdGU4SsjQyKhja8Zgu+SHZfUSO5Ls8Wsn+jsAKUUGkcshLxMg9HDFxG3KqavGWaWkJ8EpU8ojuig==",
       "dependencies": {
         "d3-path": "1 - 2"
@@ -7976,10 +8013,12 @@
     },
     "node_modules/d3-color": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
       "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
     },
     "node_modules/d3-contour": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-2.0.0.tgz",
       "integrity": "sha512-9unAtvIaNk06UwqBmvsdHX7CZ+NPDZnn8TtNH1myW93pWJkhsV25JcgnYAu0Ck5Veb1DHiCv++Ic5uvJ+h50JA==",
       "dependencies": {
         "d3-array": "2"
@@ -7987,6 +8026,7 @@
     },
     "node_modules/d3-delaunay": {
       "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-5.3.0.tgz",
       "integrity": "sha512-amALSrOllWVLaHTnDLHwMIiz0d1bBu9gZXd1FiLfXf8sHcX9jrcj81TVZOqD4UX7MgBZZ07c8GxzEgBpJqc74w==",
       "dependencies": {
         "delaunator": "4"
@@ -7994,10 +8034,12 @@
     },
     "node_modules/d3-dispatch": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
       "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA=="
     },
     "node_modules/d3-drag": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-2.0.0.tgz",
       "integrity": "sha512-g9y9WbMnF5uqB9qKqwIIa/921RYWzlUDv9Jl1/yONQwxbOfszAWTCm8u7HOTgJgRDXiRZN56cHT9pd24dmXs8w==",
       "dependencies": {
         "d3-dispatch": "1 - 2",
@@ -8006,6 +8048,7 @@
     },
     "node_modules/d3-dsv": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-2.0.0.tgz",
       "integrity": "sha512-E+Pn8UJYx9mViuIUkoc93gJGGYut6mSDKy2+XaPwccwkRGlR+LO97L2VCCRjQivTwLHkSnAJG7yo00BWY6QM+w==",
       "dependencies": {
         "commander": "2",
@@ -8026,10 +8069,12 @@
     },
     "node_modules/d3-ease": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-2.0.0.tgz",
       "integrity": "sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ=="
     },
     "node_modules/d3-fetch": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-2.0.0.tgz",
       "integrity": "sha512-TkYv/hjXgCryBeNKiclrwqZH7Nb+GaOwo3Neg24ZVWA3MKB+Rd+BY84Nh6tmNEMcjUik1CSUWjXYndmeO6F7sw==",
       "dependencies": {
         "d3-dsv": "1 - 2"
@@ -8037,6 +8082,7 @@
     },
     "node_modules/d3-force": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-2.1.1.tgz",
       "integrity": "sha512-nAuHEzBqMvpFVMf9OX75d00OxvOXdxY+xECIXjW6Gv8BRrXu6gAWbv/9XKrvfJ5i5DCokDW7RYE50LRoK092ew==",
       "dependencies": {
         "d3-dispatch": "1 - 2",
@@ -8046,21 +8092,25 @@
     },
     "node_modules/d3-format": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
       "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
     },
     "node_modules/d3-geo": {
-      "version": "2.0.1",
-      "integrity": "sha512-M6yzGbFRfxzNrVhxDJXzJqSLQ90q1cCyb3EWFZ1LF4eWOBYxFypw7I/NFVBNXKNqxv1bqLathhYvdJ6DC+th3A==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.2.tgz",
+      "integrity": "sha512-8pM1WGMLGFuhq9S+FpPURxic+gKzjluCD/CHTuUF3mXMeiCo0i6R0tO1s4+GArRFde96SLcW/kOFRjoAosPsFA==",
       "dependencies": {
-        "d3-array": ">=2.5"
+        "d3-array": "^2.5.0"
       }
     },
     "node_modules/d3-hierarchy": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz",
       "integrity": "sha512-SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw=="
     },
     "node_modules/d3-interpolate": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
       "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
       "dependencies": {
         "d3-color": "1 - 2"
@@ -8068,22 +8118,27 @@
     },
     "node_modules/d3-path": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
       "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA=="
     },
     "node_modules/d3-polygon": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-2.0.0.tgz",
       "integrity": "sha512-MsexrCK38cTGermELs0cO1d79DcTsQRN7IWMJKczD/2kBjzNXxLUWP33qRF6VDpiLV/4EI4r6Gs0DAWQkE8pSQ=="
     },
     "node_modules/d3-quadtree": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-2.0.0.tgz",
       "integrity": "sha512-b0Ed2t1UUalJpc3qXzKi+cPGxeXRr4KU9YSlocN74aTzp6R/Ud43t79yLLqxHRWZfsvWXmbDWPpoENK1K539xw=="
     },
     "node_modules/d3-random": {
       "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-2.2.2.tgz",
       "integrity": "sha512-0D9P8TRj6qDAtHhRQn6EfdOtHMfsUWanl3yb/84C4DqpZ+VsgfI5iTVRNRbELCfNvRfpMr8OrqqUTQ6ANGCijw=="
     },
     "node_modules/d3-scale": {
       "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
       "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
       "dependencies": {
         "d3-array": "^2.3.0",
@@ -8095,6 +8150,7 @@
     },
     "node_modules/d3-scale-chromatic": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-2.0.0.tgz",
       "integrity": "sha512-LLqy7dJSL8yDy7NRmf6xSlsFZ6zYvJ4BcWFE4zBrOPnQERv9zj24ohnXKRbyi9YHnYV+HN1oEO3iFK971/gkzA==",
       "dependencies": {
         "d3-color": "1 - 2",
@@ -8103,10 +8159,12 @@
     },
     "node_modules/d3-selection": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
       "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA=="
     },
     "node_modules/d3-shape": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.1.0.tgz",
       "integrity": "sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==",
       "dependencies": {
         "d3-path": "1 - 2"
@@ -8114,6 +8172,7 @@
     },
     "node_modules/d3-time": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
       "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
       "dependencies": {
         "d3-array": "2"
@@ -8121,6 +8180,7 @@
     },
     "node_modules/d3-time-format": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
       "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
       "dependencies": {
         "d3-time": "1 - 2"
@@ -8128,10 +8188,12 @@
     },
     "node_modules/d3-timer": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
       "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA=="
     },
     "node_modules/d3-transition": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-2.0.0.tgz",
       "integrity": "sha512-42ltAGgJesfQE3u9LuuBHNbGrI/AJjNL2OAUdclE70UE6Vy239GCBEYD38uBPoLeNsOhFStGpPI0BAOV+HMxog==",
       "dependencies": {
         "d3-color": "1 - 2",
@@ -8146,6 +8208,7 @@
     },
     "node_modules/d3-zoom": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-2.0.0.tgz",
       "integrity": "sha512-fFg7aoaEm9/jf+qfstak0IYpnesZLiMX6GZvXtUSdv8RH2o4E2qeelgdU09eKS6wGuiGMfcnMI0nTIqWzRHGpw==",
       "dependencies": {
         "d3-dispatch": "1 - 2",
@@ -8364,6 +8427,7 @@
     },
     "node_modules/delaunator": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
       "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag=="
     },
     "node_modules/delayed-stream": {
@@ -10765,8 +10829,9 @@
       }
     },
     "node_modules/glob-parent": {
-      "version": "5.1.1",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -11799,6 +11864,7 @@
     },
     "node_modules/internmap": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
       "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
     },
     "node_modules/invariant": {
@@ -14793,8 +14859,9 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "node_modules/picomatch": {
-      "version": "2.2.3",
-      "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "engines": {
         "node": ">=8.6"
       },
@@ -17860,6 +17927,7 @@
     },
     "node_modules/rw": {
       "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
       "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
     },
     "node_modules/rxjs": {
@@ -20676,8 +20744,9 @@
       }
     },
     "node_modules/unipept-visualizations": {
-      "version": "2.0.8",
-      "integrity": "sha512-XENrk+LkLJ54YqY+UIwb0j6yw51t64Ow3M+kQaFVeIveFVe4JBm451cjpPEfj96HyeoFjnQiUMME//V0DeUzXQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unipept-visualizations/-/unipept-visualizations-2.1.0.tgz",
+      "integrity": "sha512-H08HHqtUMOZ5z1bMy/7N3WCaOJfQsd4Tali9QSzRYRUVLqR53bSWSpc41h//Zp5gV+ccD287nVVW93rpwXl/5g==",
       "dependencies": {
         "@types/d3": "^6.2.0",
         "@typescript-eslint/eslint-plugin": "^4.17.0",
@@ -20688,24 +20757,26 @@
       }
     },
     "node_modules/unipept-visualizations/node_modules/@nodelib/fs.stat": {
-      "version": "2.0.4",
-      "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/unipept-visualizations/node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "4.24.0",
-      "integrity": "sha512-qbCgkPM7DWTsYQGjx9RTuQGswi+bEt0isqDBeo+CKV0953zqI0Tp7CZ7Fi9ipgFA6mcQqF4NOVNwS/f2r6xShw==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
+      "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "4.24.0",
-        "@typescript-eslint/scope-manager": "4.24.0",
-        "debug": "^4.1.1",
+        "@typescript-eslint/experimental-utils": "4.33.0",
+        "@typescript-eslint/scope-manager": "4.33.0",
+        "debug": "^4.3.1",
         "functional-red-black-tree": "^1.0.1",
-        "lodash": "^4.17.15",
-        "regexpp": "^3.0.0",
-        "semver": "^7.3.2",
-        "tsutils": "^3.17.1"
+        "ignore": "^5.1.8",
+        "regexpp": "^3.1.0",
+        "semver": "^7.3.5",
+        "tsutils": "^3.21.0"
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
@@ -20725,15 +20796,16 @@
       }
     },
     "node_modules/unipept-visualizations/node_modules/@typescript-eslint/experimental-utils": {
-      "version": "4.24.0",
-      "integrity": "sha512-IwTT2VNDKH1h8RZseMH4CcYBz6lTvRoOLDuuqNZZoThvfHEhOiZPQCow+5El3PtyxJ1iDr6UXZwYtE3yZQjhcw==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
+      "integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
       "dependencies": {
-        "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.24.0",
-        "@typescript-eslint/types": "4.24.0",
-        "@typescript-eslint/typescript-estree": "4.24.0",
-        "eslint-scope": "^5.0.0",
-        "eslint-utils": "^2.0.0"
+        "@types/json-schema": "^7.0.7",
+        "@typescript-eslint/scope-manager": "4.33.0",
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/typescript-estree": "4.33.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
@@ -20746,14 +20818,32 @@
         "eslint": "*"
       }
     },
-    "node_modules/unipept-visualizations/node_modules/@typescript-eslint/parser": {
-      "version": "4.24.0",
-      "integrity": "sha512-dj1ZIh/4QKeECLb2f/QjRwMmDArcwc2WorWPRlB8UNTZlY1KpTVsbX7e3ZZdphfRw29aTFUSNuGB8w9X5sS97w==",
+    "node_modules/unipept-visualizations/node_modules/@typescript-eslint/experimental-utils/node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "4.24.0",
-        "@typescript-eslint/types": "4.24.0",
-        "@typescript-eslint/typescript-estree": "4.24.0",
-        "debug": "^4.1.1"
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
+      }
+    },
+    "node_modules/unipept-visualizations/node_modules/@typescript-eslint/parser": {
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
+      "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "4.33.0",
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/typescript-estree": "4.33.0",
+        "debug": "^4.3.1"
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
@@ -20772,16 +20862,17 @@
       }
     },
     "node_modules/unipept-visualizations/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "4.24.0",
-      "integrity": "sha512-kBDitL/by/HK7g8CYLT7aKpAwlR8doshfWz8d71j97n5kUa5caHWvY0RvEUEanL/EqBJoANev8Xc/mQ6LLwXGA==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
+      "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
       "dependencies": {
-        "@typescript-eslint/types": "4.24.0",
-        "@typescript-eslint/visitor-keys": "4.24.0",
-        "debug": "^4.1.1",
-        "globby": "^11.0.1",
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/visitor-keys": "4.33.0",
+        "debug": "^4.3.1",
+        "globby": "^11.0.3",
         "is-glob": "^4.0.1",
-        "semver": "^7.3.2",
-        "tsutils": "^3.17.1"
+        "semver": "^7.3.5",
+        "tsutils": "^3.21.0"
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
@@ -20798,14 +20889,16 @@
     },
     "node_modules/unipept-visualizations/node_modules/array-union": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/unipept-visualizations/node_modules/core-js": {
-      "version": "3.12.1",
-      "integrity": "sha512-Ne9DKPHTObRuB09Dru5AjwKjY4cJHVGu+y5f7coGn1E9Grkc3p2iBwE9AI/nJzsE29mQF7oq+mhYYRqOMFN1Bw==",
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.1.tgz",
+      "integrity": "sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -20814,6 +20907,7 @@
     },
     "node_modules/unipept-visualizations/node_modules/dir-glob": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
       "dependencies": {
         "path-type": "^4.0.0"
@@ -20824,6 +20918,7 @@
     },
     "node_modules/unipept-visualizations/node_modules/eslint-scope": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -20833,43 +20928,39 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/unipept-visualizations/node_modules/eslint-utils": {
+    "node_modules/unipept-visualizations/node_modules/eslint-visitor-keys": {
       "version": "2.1.0",
-      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-      "dependencies": {
-        "eslint-visitor-keys": "^1.1.0"
-      },
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
       "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
+        "node": ">=10"
       }
     },
     "node_modules/unipept-visualizations/node_modules/fast-glob": {
-      "version": "3.2.5",
-      "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.0",
+        "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.2",
-        "picomatch": "^2.2.1"
+        "micromatch": "^4.0.4"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=8.6.0"
       }
     },
     "node_modules/unipept-visualizations/node_modules/globby": {
-      "version": "11.0.3",
-      "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -20880,14 +20971,16 @@
       }
     },
     "node_modules/unipept-visualizations/node_modules/ignore": {
-      "version": "5.1.8",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/unipept-visualizations/node_modules/lru-cache": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -20897,11 +20990,12 @@
       }
     },
     "node_modules/unipept-visualizations/node_modules/micromatch": {
-      "version": "4.0.4",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dependencies": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       },
       "engines": {
         "node": ">=8.6"
@@ -20909,14 +21003,16 @@
     },
     "node_modules/unipept-visualizations/node_modules/path-type": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/unipept-visualizations/node_modules/regexpp": {
-      "version": "3.1.0",
-      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "engines": {
         "node": ">=8"
       },
@@ -20926,6 +21022,7 @@
     },
     "node_modules/unipept-visualizations/node_modules/semver": {
       "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -20939,6 +21036,7 @@
     },
     "node_modules/unipept-visualizations/node_modules/slash": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "engines": {
         "node": ">=8"
@@ -20946,10 +21044,12 @@
     },
     "node_modules/unipept-visualizations/node_modules/tslib": {
       "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/unipept-visualizations/node_modules/tsutils": {
       "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
       "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
       "dependencies": {
         "tslib": "^1.8.1"
@@ -20963,12 +21063,13 @@
     },
     "node_modules/unipept-visualizations/node_modules/yallist": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/unipept-web-components": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/unipept-web-components/-/unipept-web-components-1.5.1.tgz",
-      "integrity": "sha512-3swjv+yooIRSdf/Obv5Id8lsgQc8Vc/xY+/+gXuBFGECOhnROcA1gdEqJtgKmXm+cDdYD58isjKHR75XbTw+pw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/unipept-web-components/-/unipept-web-components-1.5.2.tgz",
+      "integrity": "sha512-jx4P5HLf3kSdLOo6gLC2AS+pMgHOIZ8W9Fnym6JYTh2wlBih1UCWpUglwoE9Z7G7tY9jqakpcuCmuSuodK20VQ==",
       "dependencies": {
         "async": "^3.2.0",
         "axios": "^0.21.1",
@@ -20982,7 +21083,7 @@
         "jquery": "^3.4.1",
         "observable-fns": "^0.5.1",
         "shared-memory-datastructures": "0.1.9",
-        "unipept-visualizations": "^2.0.8",
+        "unipept-visualizations": "^2.1.0",
         "uuid": "^3.4.0",
         "vue": "^2.6.11",
         "vue-class-component": "^7.0.2",
@@ -25217,200 +25318,225 @@
       }
     },
     "@types/d3": {
-      "version": "6.5.0",
-      "integrity": "sha512-jVKWUprtDUVybTV73X1z2aSR5/McX+gHv7duAB6RhXksB+hlvzd6MJkRz299n2xKzOgA4fdGJdXrwIaIfaFtZw==",
+      "version": "6.7.5",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-6.7.5.tgz",
+      "integrity": "sha512-TUZ6zuT/KIvbHSv81kwAiO5gG5aTuoiLGnWR/KxHJ15Idy/xmGUXaaF5zMG+UMIsndcGlSHTmrvwRgdvZlNKaA==",
       "requires": {
-        "@types/d3-array": "*",
-        "@types/d3-axis": "*",
-        "@types/d3-brush": "*",
-        "@types/d3-chord": "*",
-        "@types/d3-color": "*",
-        "@types/d3-contour": "*",
-        "@types/d3-delaunay": "*",
-        "@types/d3-dispatch": "*",
-        "@types/d3-drag": "*",
-        "@types/d3-dsv": "*",
-        "@types/d3-ease": "*",
-        "@types/d3-fetch": "*",
-        "@types/d3-force": "*",
-        "@types/d3-format": "*",
-        "@types/d3-geo": "*",
-        "@types/d3-hierarchy": "*",
-        "@types/d3-interpolate": "*",
-        "@types/d3-path": "*",
-        "@types/d3-polygon": "*",
-        "@types/d3-quadtree": "*",
-        "@types/d3-random": "*",
-        "@types/d3-scale": "*",
-        "@types/d3-scale-chromatic": "*",
-        "@types/d3-selection": "*",
-        "@types/d3-shape": "*",
-        "@types/d3-time": "*",
-        "@types/d3-time-format": "*",
-        "@types/d3-timer": "*",
-        "@types/d3-transition": "*",
-        "@types/d3-zoom": "*"
+        "@types/d3-array": "^2",
+        "@types/d3-axis": "^2",
+        "@types/d3-brush": "^2",
+        "@types/d3-chord": "^2",
+        "@types/d3-color": "^2",
+        "@types/d3-contour": "^2",
+        "@types/d3-delaunay": "^5",
+        "@types/d3-dispatch": "^2",
+        "@types/d3-drag": "^2",
+        "@types/d3-dsv": "^2",
+        "@types/d3-ease": "^2",
+        "@types/d3-fetch": "^2",
+        "@types/d3-force": "^2",
+        "@types/d3-format": "^2",
+        "@types/d3-geo": "^2",
+        "@types/d3-hierarchy": "^2",
+        "@types/d3-interpolate": "^2",
+        "@types/d3-path": "^2",
+        "@types/d3-polygon": "^2",
+        "@types/d3-quadtree": "^2",
+        "@types/d3-random": "^2",
+        "@types/d3-scale": "^3",
+        "@types/d3-scale-chromatic": "^2",
+        "@types/d3-selection": "^2",
+        "@types/d3-shape": "^2",
+        "@types/d3-time": "^2",
+        "@types/d3-time-format": "^3",
+        "@types/d3-timer": "^2",
+        "@types/d3-transition": "^2",
+        "@types/d3-zoom": "^2"
       }
     },
     "@types/d3-array": {
-      "version": "2.11.0",
-      "integrity": "sha512-Av6SK7wIOA7sXp32+wBkCwWQI5etz/WEOmJX3fQ9+tajhUVuSU2c7NScjXn+dbbcWizKIaGLIqMGQkwCQ3KTeQ=="
+      "version": "2.12.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-2.12.3.tgz",
+      "integrity": "sha512-hN879HLPTVqZV3FQEXy7ptt083UXwguNbnxdTGzVW4y4KjX5uyNKljrQixZcSJfLyFirbpUokxpXtvR+N5+KIg=="
     },
     "@types/d3-axis": {
-      "version": "2.0.0",
-      "integrity": "sha512-gUdlEwGBLl3tXGiBnBNmNzph9W3bCfa4tBgWZD60Z1eDQKTY4zyCAcZ3LksignGfKawYatmDYcBdjJ5h/54sqA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-2.1.3.tgz",
+      "integrity": "sha512-QjXjwZ0xzyrW2ndkmkb09ErgWDEYtbLBKGui73QLMFm3woqWpxptfD5Y7vqQdybMcu7WEbjZ5q+w2w5+uh2IjA==",
       "requires": {
-        "@types/d3-selection": "*"
+        "@types/d3-selection": "^2"
       }
     },
     "@types/d3-brush": {
-      "version": "2.1.0",
-      "integrity": "sha512-rLQqxQeXWF4ArXi81GlV8HBNwJw9EDpz0jcWvvzv548EDE4tXrayBTOHYi/8Q4FZ/Df8PGXFzxpAVQmJMjOtvQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-2.1.2.tgz",
+      "integrity": "sha512-DnZmjdK1ycX1CMiW9r5E3xSf1tL+bp3yob1ON8bf0xB0/odfmGXeYOTafU+2SmU1F0/dvcqaO4SMjw62onOu6A==",
       "requires": {
-        "@types/d3-selection": "*"
+        "@types/d3-selection": "^2"
       }
     },
     "@types/d3-chord": {
-      "version": "2.0.1",
-      "integrity": "sha512-mqGww8qDtGZRnDsFizzobAVizd85hgaYNEri095ZI7/aYtW7hxa9a20enwuoVTWm0YqdCtLPoyV9ZPYgfyaTZw=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-2.0.3.tgz",
+      "integrity": "sha512-koIqSNQLPRQPXt7c55hgRF6Lr9Ps72r1+Biv55jdYR+SHJ463MsB2lp4ktzttFNmrQw/9yWthf/OmSUj5dNXKw=="
     },
     "@types/d3-color": {
-      "version": "2.0.1",
-      "integrity": "sha512-u7LTCL7RnaavFSmob2rIAJLNwu50i6gFwY9cHFr80BrQURYQBRkJ+Yv47nA3Fm7FeRhdWTiVTeqvSeOuMAOzBQ=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-2.0.3.tgz",
+      "integrity": "sha512-+0EtEjBfKEDtH9Rk3u3kLOUXM5F+iZK+WvASPb0MhIZl8J8NUvGeZRwKCXl+P3HkYx5TdU4YtcibpqHkSR9n7w=="
     },
     "@types/d3-contour": {
-      "version": "2.0.0",
-      "integrity": "sha512-PS9UO6zBQqwHXsocbpdzZFONgK1oRUgWtjjh/iz2vM06KaXLInLiKZ9e3OLBRerc1cU2uJYpO+8zOnb6frvCGQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-2.0.4.tgz",
+      "integrity": "sha512-WMac1xV/mXAgkgr5dUvzsBV5OrgNZDBDpJk9s3v2SadTqGgDRirKABb2Ek2H1pFlYVH4Oly9XJGnuzxKDduqWA==",
       "requires": {
-        "@types/d3-array": "*",
+        "@types/d3-array": "^2",
         "@types/geojson": "*"
       }
     },
     "@types/d3-delaunay": {
-      "version": "5.3.0",
-      "integrity": "sha512-gJYcGxLu0xDZPccbUe32OUpeaNtd1Lz0NYJtko6ZLMyG2euF4pBzrsQXms67LHZCDFzzszw+dMhSL/QAML3bXw=="
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-5.3.1.tgz",
+      "integrity": "sha512-F6itHi2DxdatHil1rJ2yEFUNhejj8+0Acd55LZ6Ggwbdoks0+DxVY2cawNj16sjCBiWvubVlh6eBMVsYRNGLew=="
     },
     "@types/d3-dispatch": {
-      "version": "2.0.0",
-      "integrity": "sha512-Sh0KW6z/d7uxssD7K4s4uCSzlEG/+SP+U47q098NVdOfFvUKNTvKAIV4XqjxsUuhE/854ARAREHOxkr9gQOCyg=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-2.0.1.tgz",
+      "integrity": "sha512-eT2K8uG3rXkmRiCpPn0rNrekuSLdBfV83vbTvfZliA5K7dbeaqWS/CBHtJ9SQoF8aDTsWSY4A0RU67U/HcKdJQ=="
     },
     "@types/d3-drag": {
-      "version": "2.0.0",
-      "integrity": "sha512-VaUJPjbMnDn02tcRqsHLRAX5VjcRIzCjBfeXTLGe6QjMn5JccB5Cz4ztMRXMJfkbC45ovgJFWuj6DHvWMX1thA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-2.0.2.tgz",
+      "integrity": "sha512-m9USoFaTgVw2mmE7vLjWTApT9dMxMlql/dl3Gj503x+1a2n6K455iDWydqy2dfCpkUBCoF82yRGDgcSk9FUEyQ==",
       "requires": {
-        "@types/d3-selection": "*"
+        "@types/d3-selection": "^2"
       }
     },
     "@types/d3-dsv": {
-      "version": "2.0.1",
-      "integrity": "sha512-wovgiG9Mgkr/SZ/m/c0m+RwrIT4ozsuCWeLxJyoObDWsie2DeQT4wzMdHZPR9Ya5oZLQT3w3uSl0NehG0+0dCA=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-2.0.2.tgz",
+      "integrity": "sha512-T4aL2ZzaILkLGKbxssipYVRs8334PSR9FQzTGftZbc3jIPGkiXXS7qUCh8/q8UWFzxBZQ92dvR0v7+AM9wL2PA=="
     },
     "@types/d3-ease": {
-      "version": "2.0.0",
-      "integrity": "sha512-6aZrTyX5LG+ptofVHf+gTsThLRY1nhLotJjgY4drYqk1OkJMu2UvuoZRlPw2fffjRHeYepue3/fxTufqKKmvsA=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-2.0.2.tgz",
+      "integrity": "sha512-29Y73Tg6o6aL+3/S/kEun84m5BO4bjRNau6pMWv9N9rZHcJv/O/07mW6EjqxrePZZS64fj0wiB5LMHr4Jzf3eQ=="
     },
     "@types/d3-fetch": {
-      "version": "2.0.0",
-      "integrity": "sha512-WnLepGtxepFfXRdPI8I5FTgNiHn9p4vMTTqaNCzJJfAswXx0rOY2jjeolzEU063em3iJmGZ+U79InnEeFOrCRw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-2.0.2.tgz",
+      "integrity": "sha512-sllsCSWrNdSvzOJWN5RnxkmtvW9pCttONGajSxHX9FUQ9kOkGE391xlz6VDBdZxLnpwjp3I+mipbwsaCjq4m5A==",
       "requires": {
-        "@types/d3-dsv": "*"
+        "@types/d3-dsv": "^2"
       }
     },
     "@types/d3-force": {
-      "version": "2.1.1",
-      "integrity": "sha512-3r+CQv2K/uDTAVg0DGxsbBjV02vgOxb8RhPIv3gd6cp3pdPAZ7wEXpDjUZSoqycAQLSDOxG/AZ54Vx6YXZSbmQ=="
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-2.1.4.tgz",
+      "integrity": "sha512-1XVRc2QbeUSL1FRVE53Irdz7jY+drTwESHIMVirCwkAAMB/yVC8ezAfx/1Alq0t0uOnphoyhRle1ht5CuPgSJQ=="
     },
     "@types/d3-format": {
-      "version": "2.0.0",
-      "integrity": "sha512-uagdkftxnGkO4pZw5jEYOM5ZnZOEsh7z8j11Qxk85UkB2RzfUUxRl7R9VvvJZHwKn8l+x+rpS77Nusq7FkFmIg=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-2.0.2.tgz",
+      "integrity": "sha512-OhQPuTeeMhD9A0Ksqo4q1S9Z1Q57O/t4tTPBxBQxRB4IERnxeoEYLPe72fA/GYpPSUrfKZVOgLHidkxwbzLdJA=="
     },
     "@types/d3-geo": {
-      "version": "2.0.0",
-      "integrity": "sha512-DHHgYXW36lnAEQMYU2udKVOxxljHrn2EdOINeSC9jWCAXwOnGn7A19B8sNsHqgpu4F7O2bSD7//cqBXD3W0Deg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-2.0.3.tgz",
+      "integrity": "sha512-kFwLEMXq1mGJ2Eho7KrOUYvLcc2YTDeKj+kTFt87JlEbRQ0rgo8ZENNb5vTYmZrJ2xL/vVM5M7yqVZGOPH2JFg==",
       "requires": {
         "@types/geojson": "*"
       }
     },
     "@types/d3-hierarchy": {
-      "version": "2.0.0",
-      "integrity": "sha512-YxdskUvwzqggpnSnDQj4KVkicgjpkgXn/g/9M9iGsiToLS3nG6Ytjo1FoYhYVAAElV/fJBGVL3cQ9Hb7tcv+lw=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-2.0.2.tgz",
+      "integrity": "sha512-6PlBRwbjUPPt0ZFq/HTUyOAdOF3p73EUYots74lHMUyAVtdFSOS/hAeNXtEIM9i7qRDntuIblXxHGUMb9MuNRA=="
     },
     "@types/d3-interpolate": {
-      "version": "2.0.0",
-      "integrity": "sha512-Wt1v2zTlEN8dSx8hhx6MoOhWQgTkz0Ukj7owAEIOF2QtI0e219paFX9rf/SLOr/UExWb1TcUzatU8zWwFby6gg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-2.0.2.tgz",
+      "integrity": "sha512-lElyqlUfIPyWG/cD475vl6msPL4aMU7eJvx1//Q177L8mdXoVPFl1djIESF2FKnc0NyaHvQlJpWwKJYwAhUoCw==",
       "requires": {
-        "@types/d3-color": "*"
+        "@types/d3-color": "^2"
       }
     },
     "@types/d3-path": {
-      "version": "2.0.0",
-      "integrity": "sha512-tXcR/9OtDdeCIsyl6eTNHC3XOAOdyc6ceF3QGBXOd9jTcK+ex/ecr00p9L9362e/op3UEPpxrToi1FHrtTSj7Q=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-2.0.2.tgz",
+      "integrity": "sha512-3YHpvDw9LzONaJzejXLOwZ3LqwwkoXb9LI2YN7Hbd6pkGo5nIlJ09ul4bQhBN4hQZJKmUpX8HkVqbzgUKY48cg=="
     },
     "@types/d3-polygon": {
-      "version": "2.0.0",
-      "integrity": "sha512-fISnMd8ePED1G4aa4V974Jmt+ajHSgPoxMa2D0ULxMybpx0Vw4WEzhQEaMIrL3hM8HVRcKTx669I+dTy/4PhAw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-2.0.1.tgz",
+      "integrity": "sha512-X3XTIwBxlzRIWe4yaD1KsmcfItjSPLTGL04QDyP08jyHDVsnz3+NZJMwtD4vCaTAVpGSjbqS+jrBo8cO2V/xMA=="
     },
     "@types/d3-quadtree": {
-      "version": "2.0.0",
-      "integrity": "sha512-YZuJuGBnijD0H+98xMJD4oZXgv/umPXy5deu3IimYTPGH3Kr8Th6iQUff0/6S80oNBD7KtOuIHwHUCymUiRoeQ=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-2.0.2.tgz",
+      "integrity": "sha512-KgWL4jlz8QJJZX01E4HKXJ9FLU94RTuObsAYqsPp8YOAcYDmEgJIQJ+ojZcnKUAnrUb78ik8JBKWas5XZPqJnQ=="
     },
     "@types/d3-random": {
-      "version": "2.2.0",
-      "integrity": "sha512-Hjfj9m68NmYZzushzEG7etPvKH/nj9b9s9+qtkNG3/dbRBjQZQg1XS6nRuHJcCASTjxXlyXZnKu2gDxyQIIu9A=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-2.2.1.tgz",
+      "integrity": "sha512-5vvxn6//poNeOxt1ZwC7QU//dG9QqABjy1T7fP/xmFHY95GnaOw3yABf29hiu5SR1Oo34XcpyHFbzod+vemQjA=="
     },
     "@types/d3-scale": {
-      "version": "3.2.2",
-      "integrity": "sha512-qpQe8G02tzUwt9sdWX1h8A/W0Q1+N48wMnYXVOkrzeLUkCfvzJYV9Ee3aORCS4dN4ONRLFmMvaXdziQ29XGLjQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-3.3.2.tgz",
+      "integrity": "sha512-gGqr7x1ost9px3FvIfUMi5XA/F/yAf4UkUDtdQhpH92XCT0Oa7zkkRzY61gPVJq+DxpHn/btouw5ohWkbBsCzQ==",
       "requires": {
-        "@types/d3-time": "*"
+        "@types/d3-time": "^2"
       }
     },
     "@types/d3-scale-chromatic": {
-      "version": "2.0.0",
-      "integrity": "sha512-Y62+2clOwZoKua84Ha0xU77w7lePiaBoTjXugT4l8Rd5LAk+Mn/ZDtrgs087a+B5uJ3jYUHHtKw5nuEzp0WBHw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-2.0.1.tgz",
+      "integrity": "sha512-3EuZlbPu+pvclZcb1DhlymTWT2W+lYsRKBjvkH2ojDbCWDYavifqu1vYX9WGzlPgCgcS4Alhk1+zapXbGEGylQ=="
     },
     "@types/d3-selection": {
-      "version": "2.0.0",
-      "integrity": "sha512-EF0lWZ4tg7oDFg4YQFlbOU3936e3a9UmoQ2IXlBy1+cv2c2Pv7knhKUzGlH5Hq2sF/KeDTH1amiRPey2rrLMQA=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-2.0.1.tgz",
+      "integrity": "sha512-3mhtPnGE+c71rl/T5HMy+ykg7migAZ4T6gzU0HxpgBFKcasBrSnwRbYV1/UZR6o5fkpySxhWxAhd7yhjj8jL7g=="
     },
     "@types/d3-shape": {
-      "version": "2.0.0",
-      "integrity": "sha512-NLzD02m5PiD1KLEDjLN+MtqEcFYn4ZL9+Rqc9ZwARK1cpKZXd91zBETbe6wpBB6Ia0D0VZbpmbW3+BsGPGnCpA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-2.1.3.tgz",
+      "integrity": "sha512-HAhCel3wP93kh4/rq+7atLdybcESZ5bRHDEZUojClyZWsRuEMo3A52NGYJSh48SxfxEU6RZIVbZL2YFZ2OAlzQ==",
       "requires": {
-        "@types/d3-path": "^1"
-      },
-      "dependencies": {
-        "@types/d3-path": {
-          "version": "1.0.9",
-          "integrity": "sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ=="
-        }
+        "@types/d3-path": "^2"
       }
     },
     "@types/d3-time": {
-      "version": "2.0.0",
-      "integrity": "sha512-Abz8bTzy8UWDeYs9pCa3D37i29EWDjNTjemdk0ei1ApYVNqulYlGUKip/jLOpogkPSsPz/GvZCYiC7MFlEk0iQ=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-2.1.1.tgz",
+      "integrity": "sha512-9MVYlmIgmRR31C5b4FVSWtuMmBHh2mOWQYfl7XAYOa8dsnb7iEmUmRSWSFgXFtkjxO65d7hTUHQC+RhR/9IWFg=="
     },
     "@types/d3-time-format": {
-      "version": "3.0.0",
-      "integrity": "sha512-UpLg1mn/8PLyjr+J/JwdQJM/GzysMvv2CS8y+WYAL5K0+wbvXv/pPSLEfdNaprCZsGcXTxPsFMy8QtkYv9ueew=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-3.0.1.tgz",
+      "integrity": "sha512-5GIimz5IqaRsdnxs4YlyTZPwAMfALu/wA4jqSiuqgdbCxUZ2WjrnwANqOtoBJQgeaUTdYNfALJO0Yb0YrDqduA=="
     },
     "@types/d3-timer": {
-      "version": "2.0.0",
-      "integrity": "sha512-l6stHr1VD1BWlW6u3pxrjLtJfpPZq9I3XmKIQtq7zHM/s6fwEtI1Yn6Sr5/jQTrUDCC5jkS6gWqlFGCDArDqNg=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-2.0.1.tgz",
+      "integrity": "sha512-TF8aoF5cHcLO7W7403blM7L1T+6NF3XMyN3fxyUolq2uOcFeicG/khQg/dGxiCJWoAcmYulYN7LYSRKO54IXaA=="
     },
     "@types/d3-transition": {
-      "version": "2.0.0",
-      "integrity": "sha512-UJDzI98utcZQUJt3uIit/Ho0/eBIANzrWJrTmi4+TaKIyWL2iCu7ShP0o4QajCskhyjOA7C8+4CE3b1YirTzEQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-2.0.2.tgz",
+      "integrity": "sha512-376TICEykdXOEA9uUIYpjshEkxfGwCPnkHUl8+6gphzKbf5NMnUhKT7wR59Yxrd9wtJ/rmE3SVLx6/8w4eY6Zg==",
       "requires": {
-        "@types/d3-selection": "*"
+        "@types/d3-selection": "^2"
       }
     },
     "@types/d3-zoom": {
-      "version": "2.0.1",
-      "integrity": "sha512-FuiGLfaHmp84b9wsj0dG03E/aJl5k98OLnJ2/5p7bQOHEpWqR+z5WCoWYMAbdGxaca7VNd9tCT5i6AJnpauNTQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-2.0.3.tgz",
+      "integrity": "sha512-9X9uDYKk2U8w775OHj36s9Q7GkNAnJKGw6+sbkP5DpHSjELwKvTGzEK6+IISYfLpJRL/V3mRXMhgDnnJ5LkwJg==",
       "requires": {
-        "@types/d3-interpolate": "*",
-        "@types/d3-selection": "*"
+        "@types/d3-interpolate": "^2",
+        "@types/d3-selection": "^2"
       }
     },
     "@types/debug": {
@@ -25450,8 +25576,9 @@
       }
     },
     "@types/geojson": {
-      "version": "7946.0.7",
-      "integrity": "sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ=="
+      "version": "7946.0.8",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
+      "integrity": "sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA=="
     },
     "@types/glob": {
       "version": "7.1.3",
@@ -25668,16 +25795,18 @@
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.24.0",
-      "integrity": "sha512-9+WYJGDnuC9VtYLqBhcSuM7du75fyCS/ypC8c5g7Sdw7pGL4NDTbeH38eJPfzIydCHZDoOgjloxSAA3+4l/zsA==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
+      "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
       "requires": {
-        "@typescript-eslint/types": "4.24.0",
-        "@typescript-eslint/visitor-keys": "4.24.0"
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/visitor-keys": "4.33.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.24.0",
-      "integrity": "sha512-tkZUBgDQKdvfs8L47LaqxojKDE+mIUmOzdz7r+u+U54l3GDkTpEbQ1Jp3cNqqAU9vMUCBA1fitsIhm7yN0vx9Q=="
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
+      "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ=="
     },
     "@typescript-eslint/typescript-estree": {
       "version": "1.13.0",
@@ -25696,15 +25825,17 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.24.0",
-      "integrity": "sha512-4ox1sjmGHIxjEDBnMCtWFFhErXtKA1Ec0sBpuz0fqf3P+g3JFGyTxxbF06byw0FRsPnnbq44cKivH7Ks1/0s6g==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
+      "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
       "requires": {
-        "@typescript-eslint/types": "4.24.0",
+        "@typescript-eslint/types": "4.33.0",
         "eslint-visitor-keys": "^2.0.0"
       },
       "dependencies": {
         "eslint-visitor-keys": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
           "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw=="
         }
       }
@@ -30309,6 +30440,7 @@
     },
     "d3": {
       "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-6.7.0.tgz",
       "integrity": "sha512-hNHRhe+yCDLUG6Q2LwvR/WdNFPOJQ5VWqsJcwIYVeI401+d2/rrCjxSXkiAdIlpx7/73eApFB4Olsmh3YN7a6g==",
       "requires": {
         "d3-array": "2",
@@ -30345,6 +30477,7 @@
     },
     "d3-array": {
       "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
       "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
       "requires": {
         "internmap": "^1.0.0"
@@ -30352,10 +30485,12 @@
     },
     "d3-axis": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-2.1.0.tgz",
       "integrity": "sha512-z/G2TQMyuf0X3qP+Mh+2PimoJD41VOCjViJzT0BHeL/+JQAofkiWZbWxlwFGb1N8EN+Cl/CW+MUKbVzr1689Cw=="
     },
     "d3-brush": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-2.1.0.tgz",
       "integrity": "sha512-cHLLAFatBATyIKqZOkk/mDHUbzne2B3ZwxkzMHvFTCZCmLaXDpZRihQSn8UNXTkGD/3lb/W2sQz0etAftmHMJQ==",
       "requires": {
         "d3-dispatch": "1 - 2",
@@ -30367,6 +30502,7 @@
     },
     "d3-chord": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-2.0.0.tgz",
       "integrity": "sha512-D5PZb7EDsRNdGU4SsjQyKhja8Zgu+SHZfUSO5Ls8Wsn+jsAKUUGkcshLxMg9HDFxG3KqavGWaWkJ8EpU8ojuig==",
       "requires": {
         "d3-path": "1 - 2"
@@ -30374,10 +30510,12 @@
     },
     "d3-color": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
       "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
     },
     "d3-contour": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-2.0.0.tgz",
       "integrity": "sha512-9unAtvIaNk06UwqBmvsdHX7CZ+NPDZnn8TtNH1myW93pWJkhsV25JcgnYAu0Ck5Veb1DHiCv++Ic5uvJ+h50JA==",
       "requires": {
         "d3-array": "2"
@@ -30385,6 +30523,7 @@
     },
     "d3-delaunay": {
       "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-5.3.0.tgz",
       "integrity": "sha512-amALSrOllWVLaHTnDLHwMIiz0d1bBu9gZXd1FiLfXf8sHcX9jrcj81TVZOqD4UX7MgBZZ07c8GxzEgBpJqc74w==",
       "requires": {
         "delaunator": "4"
@@ -30392,10 +30531,12 @@
     },
     "d3-dispatch": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
       "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA=="
     },
     "d3-drag": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-2.0.0.tgz",
       "integrity": "sha512-g9y9WbMnF5uqB9qKqwIIa/921RYWzlUDv9Jl1/yONQwxbOfszAWTCm8u7HOTgJgRDXiRZN56cHT9pd24dmXs8w==",
       "requires": {
         "d3-dispatch": "1 - 2",
@@ -30404,6 +30545,7 @@
     },
     "d3-dsv": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-2.0.0.tgz",
       "integrity": "sha512-E+Pn8UJYx9mViuIUkoc93gJGGYut6mSDKy2+XaPwccwkRGlR+LO97L2VCCRjQivTwLHkSnAJG7yo00BWY6QM+w==",
       "requires": {
         "commander": "2",
@@ -30413,10 +30555,12 @@
     },
     "d3-ease": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-2.0.0.tgz",
       "integrity": "sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ=="
     },
     "d3-fetch": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-2.0.0.tgz",
       "integrity": "sha512-TkYv/hjXgCryBeNKiclrwqZH7Nb+GaOwo3Neg24ZVWA3MKB+Rd+BY84Nh6tmNEMcjUik1CSUWjXYndmeO6F7sw==",
       "requires": {
         "d3-dsv": "1 - 2"
@@ -30424,6 +30568,7 @@
     },
     "d3-force": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-2.1.1.tgz",
       "integrity": "sha512-nAuHEzBqMvpFVMf9OX75d00OxvOXdxY+xECIXjW6Gv8BRrXu6gAWbv/9XKrvfJ5i5DCokDW7RYE50LRoK092ew==",
       "requires": {
         "d3-dispatch": "1 - 2",
@@ -30433,21 +30578,25 @@
     },
     "d3-format": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
       "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
     },
     "d3-geo": {
-      "version": "2.0.1",
-      "integrity": "sha512-M6yzGbFRfxzNrVhxDJXzJqSLQ90q1cCyb3EWFZ1LF4eWOBYxFypw7I/NFVBNXKNqxv1bqLathhYvdJ6DC+th3A==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.2.tgz",
+      "integrity": "sha512-8pM1WGMLGFuhq9S+FpPURxic+gKzjluCD/CHTuUF3mXMeiCo0i6R0tO1s4+GArRFde96SLcW/kOFRjoAosPsFA==",
       "requires": {
-        "d3-array": ">=2.5"
+        "d3-array": "^2.5.0"
       }
     },
     "d3-hierarchy": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz",
       "integrity": "sha512-SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw=="
     },
     "d3-interpolate": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
       "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
       "requires": {
         "d3-color": "1 - 2"
@@ -30455,22 +30604,27 @@
     },
     "d3-path": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
       "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA=="
     },
     "d3-polygon": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-2.0.0.tgz",
       "integrity": "sha512-MsexrCK38cTGermELs0cO1d79DcTsQRN7IWMJKczD/2kBjzNXxLUWP33qRF6VDpiLV/4EI4r6Gs0DAWQkE8pSQ=="
     },
     "d3-quadtree": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-2.0.0.tgz",
       "integrity": "sha512-b0Ed2t1UUalJpc3qXzKi+cPGxeXRr4KU9YSlocN74aTzp6R/Ud43t79yLLqxHRWZfsvWXmbDWPpoENK1K539xw=="
     },
     "d3-random": {
       "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-2.2.2.tgz",
       "integrity": "sha512-0D9P8TRj6qDAtHhRQn6EfdOtHMfsUWanl3yb/84C4DqpZ+VsgfI5iTVRNRbELCfNvRfpMr8OrqqUTQ6ANGCijw=="
     },
     "d3-scale": {
       "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
       "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
       "requires": {
         "d3-array": "^2.3.0",
@@ -30482,6 +30636,7 @@
     },
     "d3-scale-chromatic": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-2.0.0.tgz",
       "integrity": "sha512-LLqy7dJSL8yDy7NRmf6xSlsFZ6zYvJ4BcWFE4zBrOPnQERv9zj24ohnXKRbyi9YHnYV+HN1oEO3iFK971/gkzA==",
       "requires": {
         "d3-color": "1 - 2",
@@ -30490,10 +30645,12 @@
     },
     "d3-selection": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
       "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA=="
     },
     "d3-shape": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.1.0.tgz",
       "integrity": "sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==",
       "requires": {
         "d3-path": "1 - 2"
@@ -30501,6 +30658,7 @@
     },
     "d3-time": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
       "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
       "requires": {
         "d3-array": "2"
@@ -30508,6 +30666,7 @@
     },
     "d3-time-format": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
       "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
       "requires": {
         "d3-time": "1 - 2"
@@ -30515,10 +30674,12 @@
     },
     "d3-timer": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
       "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA=="
     },
     "d3-transition": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-2.0.0.tgz",
       "integrity": "sha512-42ltAGgJesfQE3u9LuuBHNbGrI/AJjNL2OAUdclE70UE6Vy239GCBEYD38uBPoLeNsOhFStGpPI0BAOV+HMxog==",
       "requires": {
         "d3-color": "1 - 2",
@@ -30530,6 +30691,7 @@
     },
     "d3-zoom": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-2.0.0.tgz",
       "integrity": "sha512-fFg7aoaEm9/jf+qfstak0IYpnesZLiMX6GZvXtUSdv8RH2o4E2qeelgdU09eKS6wGuiGMfcnMI0nTIqWzRHGpw==",
       "requires": {
         "d3-dispatch": "1 - 2",
@@ -30696,6 +30858,7 @@
     },
     "delaunator": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
       "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag=="
     },
     "delayed-stream": {
@@ -32592,8 +32755,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.1",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -33387,6 +33551,7 @@
     },
     "internmap": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
       "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
     },
     "invariant": {
@@ -35682,8 +35847,9 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picomatch": {
-      "version": "2.2.3",
-      "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "pify": {
       "version": "4.0.1",
@@ -38003,6 +38169,7 @@
     },
     "rw": {
       "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
       "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
     },
     "rxjs": {
@@ -40207,8 +40374,9 @@
       }
     },
     "unipept-visualizations": {
-      "version": "2.0.8",
-      "integrity": "sha512-XENrk+LkLJ54YqY+UIwb0j6yw51t64Ow3M+kQaFVeIveFVe4JBm451cjpPEfj96HyeoFjnQiUMME//V0DeUzXQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unipept-visualizations/-/unipept-visualizations-2.1.0.tgz",
+      "integrity": "sha512-H08HHqtUMOZ5z1bMy/7N3WCaOJfQsd4Tali9QSzRYRUVLqR53bSWSpc41h//Zp5gV+ccD287nVVW93rpwXl/5g==",
       "requires": {
         "@types/d3": "^6.2.0",
         "@typescript-eslint/eslint-plugin": "^4.17.0",
@@ -40219,68 +40387,86 @@
       },
       "dependencies": {
         "@nodelib/fs.stat": {
-          "version": "2.0.4",
-          "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q=="
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+          "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
         },
         "@typescript-eslint/eslint-plugin": {
-          "version": "4.24.0",
-          "integrity": "sha512-qbCgkPM7DWTsYQGjx9RTuQGswi+bEt0isqDBeo+CKV0953zqI0Tp7CZ7Fi9ipgFA6mcQqF4NOVNwS/f2r6xShw==",
+          "version": "4.33.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
+          "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
           "requires": {
-            "@typescript-eslint/experimental-utils": "4.24.0",
-            "@typescript-eslint/scope-manager": "4.24.0",
-            "debug": "^4.1.1",
+            "@typescript-eslint/experimental-utils": "4.33.0",
+            "@typescript-eslint/scope-manager": "4.33.0",
+            "debug": "^4.3.1",
             "functional-red-black-tree": "^1.0.1",
-            "lodash": "^4.17.15",
-            "regexpp": "^3.0.0",
-            "semver": "^7.3.2",
-            "tsutils": "^3.17.1"
+            "ignore": "^5.1.8",
+            "regexpp": "^3.1.0",
+            "semver": "^7.3.5",
+            "tsutils": "^3.21.0"
           }
         },
         "@typescript-eslint/experimental-utils": {
-          "version": "4.24.0",
-          "integrity": "sha512-IwTT2VNDKH1h8RZseMH4CcYBz6lTvRoOLDuuqNZZoThvfHEhOiZPQCow+5El3PtyxJ1iDr6UXZwYtE3yZQjhcw==",
+          "version": "4.33.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
+          "integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
           "requires": {
-            "@types/json-schema": "^7.0.3",
-            "@typescript-eslint/scope-manager": "4.24.0",
-            "@typescript-eslint/types": "4.24.0",
-            "@typescript-eslint/typescript-estree": "4.24.0",
-            "eslint-scope": "^5.0.0",
-            "eslint-utils": "^2.0.0"
+            "@types/json-schema": "^7.0.7",
+            "@typescript-eslint/scope-manager": "4.33.0",
+            "@typescript-eslint/types": "4.33.0",
+            "@typescript-eslint/typescript-estree": "4.33.0",
+            "eslint-scope": "^5.1.1",
+            "eslint-utils": "^3.0.0"
+          },
+          "dependencies": {
+            "eslint-utils": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+              "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+              "requires": {
+                "eslint-visitor-keys": "^2.0.0"
+              }
+            }
           }
         },
         "@typescript-eslint/parser": {
-          "version": "4.24.0",
-          "integrity": "sha512-dj1ZIh/4QKeECLb2f/QjRwMmDArcwc2WorWPRlB8UNTZlY1KpTVsbX7e3ZZdphfRw29aTFUSNuGB8w9X5sS97w==",
+          "version": "4.33.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
+          "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
           "requires": {
-            "@typescript-eslint/scope-manager": "4.24.0",
-            "@typescript-eslint/types": "4.24.0",
-            "@typescript-eslint/typescript-estree": "4.24.0",
-            "debug": "^4.1.1"
+            "@typescript-eslint/scope-manager": "4.33.0",
+            "@typescript-eslint/types": "4.33.0",
+            "@typescript-eslint/typescript-estree": "4.33.0",
+            "debug": "^4.3.1"
           }
         },
         "@typescript-eslint/typescript-estree": {
-          "version": "4.24.0",
-          "integrity": "sha512-kBDitL/by/HK7g8CYLT7aKpAwlR8doshfWz8d71j97n5kUa5caHWvY0RvEUEanL/EqBJoANev8Xc/mQ6LLwXGA==",
+          "version": "4.33.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
+          "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
           "requires": {
-            "@typescript-eslint/types": "4.24.0",
-            "@typescript-eslint/visitor-keys": "4.24.0",
-            "debug": "^4.1.1",
-            "globby": "^11.0.1",
+            "@typescript-eslint/types": "4.33.0",
+            "@typescript-eslint/visitor-keys": "4.33.0",
+            "debug": "^4.3.1",
+            "globby": "^11.0.3",
             "is-glob": "^4.0.1",
-            "semver": "^7.3.2",
-            "tsutils": "^3.17.1"
+            "semver": "^7.3.5",
+            "tsutils": "^3.21.0"
           }
         },
         "array-union": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
           "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
         },
         "core-js": {
-          "version": "3.12.1",
-          "integrity": "sha512-Ne9DKPHTObRuB09Dru5AjwKjY4cJHVGu+y5f7coGn1E9Grkc3p2iBwE9AI/nJzsE29mQF7oq+mhYYRqOMFN1Bw=="
+          "version": "3.21.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.1.tgz",
+          "integrity": "sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig=="
         },
         "dir-glob": {
           "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
           "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
           "requires": {
             "path-type": "^4.0.0"
@@ -40288,72 +40474,78 @@
         },
         "eslint-scope": {
           "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
           "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
           "requires": {
             "esrecurse": "^4.3.0",
             "estraverse": "^4.1.1"
           }
         },
-        "eslint-utils": {
+        "eslint-visitor-keys": {
           "version": "2.1.0",
-          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-          "requires": {
-            "eslint-visitor-keys": "^1.1.0"
-          }
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw=="
         },
         "fast-glob": {
-          "version": "3.2.5",
-          "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+          "version": "3.2.11",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+          "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
           "requires": {
             "@nodelib/fs.stat": "^2.0.2",
             "@nodelib/fs.walk": "^1.2.3",
-            "glob-parent": "^5.1.0",
+            "glob-parent": "^5.1.2",
             "merge2": "^1.3.0",
-            "micromatch": "^4.0.2",
-            "picomatch": "^2.2.1"
+            "micromatch": "^4.0.4"
           }
         },
         "globby": {
-          "version": "11.0.3",
-          "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+          "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
           "requires": {
             "array-union": "^2.1.0",
             "dir-glob": "^3.0.1",
-            "fast-glob": "^3.1.1",
-            "ignore": "^5.1.4",
-            "merge2": "^1.3.0",
+            "fast-glob": "^3.2.9",
+            "ignore": "^5.2.0",
+            "merge2": "^1.4.1",
             "slash": "^3.0.0"
           }
         },
         "ignore": {
-          "version": "5.1.8",
-          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
         },
         "lru-cache": {
           "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "requires": {
             "yallist": "^4.0.0"
           }
         },
         "micromatch": {
-          "version": "4.0.4",
-          "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+          "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+          "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
           "requires": {
-            "braces": "^3.0.1",
-            "picomatch": "^2.2.3"
+            "braces": "^3.0.2",
+            "picomatch": "^2.3.1"
           }
         },
         "path-type": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
           "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
         },
         "regexpp": {
-          "version": "3.1.0",
-          "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q=="
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+          "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg=="
         },
         "semver": {
           "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
           "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "requires": {
             "lru-cache": "^6.0.0"
@@ -40361,14 +40553,17 @@
         },
         "slash": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
           "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
         },
         "tslib": {
           "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "tsutils": {
           "version": "3.21.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
           "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
           "requires": {
             "tslib": "^1.8.1"
@@ -40376,14 +40571,15 @@
         },
         "yallist": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
     "unipept-web-components": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/unipept-web-components/-/unipept-web-components-1.5.1.tgz",
-      "integrity": "sha512-3swjv+yooIRSdf/Obv5Id8lsgQc8Vc/xY+/+gXuBFGECOhnROcA1gdEqJtgKmXm+cDdYD58isjKHR75XbTw+pw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/unipept-web-components/-/unipept-web-components-1.5.2.tgz",
+      "integrity": "sha512-jx4P5HLf3kSdLOo6gLC2AS+pMgHOIZ8W9Fnym6JYTh2wlBih1UCWpUglwoE9Z7G7tY9jqakpcuCmuSuodK20VQ==",
       "requires": {
         "async": "^3.2.0",
         "axios": "^0.21.1",
@@ -40397,7 +40593,7 @@
         "jquery": "^3.4.1",
         "observable-fns": "^0.5.1",
         "shared-memory-datastructures": "0.1.9",
-        "unipept-visualizations": "^2.0.8",
+        "unipept-visualizations": "^2.1.0",
         "uuid": "^3.4.0",
         "vue": "^2.6.11",
         "vue-class-component": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "node-abi": "^2.19.3",
     "regenerator-runtime": "^0.13.3",
     "shared-memory-datastructures": "0.1.9",
-    "unipept-web-components": "^1.5.1",
+    "unipept-web-components": "^1.5.2",
     "uuid": "^7.0.3",
     "vue": "^2.6.12",
     "vue-class-component": "^7.1.0",

--- a/src/components/analysis/AnalysisSummary.vue
+++ b/src/components/analysis/AnalysisSummary.vue
@@ -90,12 +90,14 @@
                                     Update
                                 </v-btn>
                             </tooltip>
-                            <export-results-button :assay="assay" button-text="Export results"></export-results-button>
                         </div>
                     </v-col>
+
                     <v-col sm="12" lg="6">
-                        <peptide-summary-table :assay="assay">
-                        </peptide-summary-table>
+                        <peptide-summary-table :assay="assay" />
+                        <div class="d-flex justify-center">
+                            <export-results-button :assay="assay" button-text="Export results" />
+                        </div>
                     </v-col>
                 </v-row>
             </v-container>

--- a/src/components/analysis/AnalysisSummary.vue
+++ b/src/components/analysis/AnalysisSummary.vue
@@ -1,5 +1,5 @@
 <template>
-    <v-card v-if="assay && peptideTrust">
+    <v-card v-if="assay && originalPeptideTrust">
         <v-card-title>
             {{ assay.getName() }}
         </v-card-title>
@@ -18,8 +18,19 @@
                             <div class="flex-grow-1 d-flex align-start flex-column ml-12">
                                 <div class="title">Metaproteomics sample</div>
                                 <div class="subtitle-1">
-                                    {{ peptideTrust.matchedPeptides }} peptides found,
-                                    {{ peptideTrust.searchedPeptides }} peptides in assay
+                                    {{ originalPeptideTrust.matchedPeptides }} peptides found,
+                                    {{ originalPeptideTrust.searchedPeptides }} peptides in assay
+                                </div>
+                                <div>
+                                    <span v-if="!filteredPeptideTrust">
+                                        Applying filter...
+                                    </span>
+                                    <span v-else-if="isFilterApplied">
+                                        {{ filteredPeptideTrust.matchedPeptides }} peptides in current selection
+                                    </span>
+                                    <span v-else>
+                                        No filter applied
+                                    </span>
                                 </div>
                                 <div class="subtitle-2">Last analysed on {{ getHumanReadableAssayDate() }}</div>
 
@@ -153,8 +164,16 @@ export default class AnalysisSummary extends Vue {
 
     private searchConfigIsValid: boolean = true;
 
-    get peptideTrust(): PeptideTrust {
-        return this.$store.getters.assayData(this.assay)?.peptideTrust;
+    get originalPeptideTrust(): PeptideTrust {
+        return this.$store.getters.assayData(this.assay)?.originalData?.trust;
+    }
+
+    get filteredPeptideTrust(): PeptideTrust {
+        return this.$store.getters.assayData(this.assay)?.filteredData?.trust;
+    }
+
+    get isFilterApplied(): boolean {
+        return this.$store.getters.assayData(this.assay)?.filterId !== 1;
     }
 
     get endpoint(): string {

--- a/src/components/analysis/PeptideSummaryTable.vue
+++ b/src/components/analysis/PeptideSummaryTable.vue
@@ -81,12 +81,14 @@ export default class PeptideSummaryTable extends Vue {
 
     private loading: boolean = true;
 
+    private showFiltered: boolean = false;
+
     get totalItems(): number {
         return this.peptideCountTable?.totalCount;
     }
 
     get peptideCountTable(): CountTable<Peptide> {
-        return this.$store.getters.assayData(this.assay)?.originalData?.peptideCountTable;
+        return this.$store.getters.assayData(this.assay)?.filteredData?.peptideCountTable;
     }
 
     get lcaOntology(): Ontology<NcbiId, NcbiTaxon> {

--- a/src/components/pages/analysis/AnalysisPage.vue
+++ b/src/components/pages/analysis/AnalysisPage.vue
@@ -12,6 +12,26 @@
                 You are currently browsing the demo project. Changes made to this project will not be saved.
             </v-alert>
 
+            <v-alert
+                v-if="isFilterActive"
+                class="ma-2"
+                type="info">
+                <v-row dense align="center">
+                    <v-col class="grow">
+                        <b>
+                            Filtered results:
+                        </b>
+                        these results are limited to the {{ this.filteredTrust.matchedPeptides }} peptides specific to
+                        <b>
+                            {{ this.filteredNcbiTaxon.name }} ({{this.filteredNcbiTaxon.rank}})
+                        </b>
+                    </v-col>
+                    <v-col class="shrink">
+                        <v-btn @click="resetFilter" color="white" class="black--text" x-small>Reset filter</v-btn>
+                    </v-col>
+                </v-row>
+            </v-alert>
+
             <!-- Show analysis results for the currently selected assay if it's ready with processing -->
             <v-container
                 v-if="!errorStatus && activeAssay && activeAssay.analysisReady"
@@ -138,7 +158,14 @@
 <script lang="ts">
 import Vue from "vue";
 import Component from "vue-class-component";
-import { ProteomicsAssay, AssayAnalysisStatus, StringUtils, Study, ProgressReport } from "unipept-web-components";
+import {
+    ProteomicsAssay,
+    AssayAnalysisStatus,
+    StringUtils,
+    Study,
+    ProgressReport,
+    PeptideTrust, NcbiTaxon, Ontology, NcbiId
+} from "unipept-web-components";
 import Snake from "@/components/games/Snake.vue";
 import Toolbar from "@/components/navigation-drawers/Toolbar.vue";
 import ProjectExplorer from "@/components/navigation-drawers/ProjectExplorer.vue";
@@ -207,6 +234,26 @@ export default class AnalysisPage extends Vue {
         return projectLocation && projectLocation.includes(tempPath);
     }
 
+    get filteredId(): NcbiId {
+        return this.activeAssay?.filterId;
+    }
+
+    get isFilterActive(): boolean {
+        return this.filteredId !== 1;
+    }
+
+    get filteredTrust(): PeptideTrust {
+        return this.activeAssay?.filteredData?.trust;
+    }
+
+    get ncbiOntology(): Ontology<NcbiId, NcbiTaxon> {
+        return this.activeAssay?.ncbiOntology;
+    }
+
+    get filteredNcbiTaxon(): NcbiTaxon {
+        return this.ncbiOntology.getDefinition(this.filteredId);
+    }
+
     private reanalyse() {
         if (this.activeAssay) {
             this.$store.dispatch("analyseAssay", this.activeAssay.assay);
@@ -230,6 +277,10 @@ export default class AnalysisPage extends Vue {
 
     private msToTimeString(ms: number) {
         return StringUtils.secondsToTimeString(ms / 1000);
+    }
+
+    private resetFilter() {
+        this.$store.dispatch("filterAssayByTaxon", [this.activeAssay.assay, 1]);
     }
 }
 </script>

--- a/src/components/pages/analysis/AnalysisPage.vue
+++ b/src/components/pages/analysis/AnalysisPage.vue
@@ -13,7 +13,7 @@
             </v-alert>
 
             <v-alert
-                v-if="isFilterActive"
+                v-if="isFilterActive && filteredTrust"
                 class="ma-2"
                 type="info">
                 <v-row dense align="center">

--- a/src/components/pages/analysis/SingleAssayAnalysisPage.vue
+++ b/src/components/pages/analysis/SingleAssayAnalysisPage.vue
@@ -10,6 +10,7 @@
                 <single-dataset-visualizations-card
                     :assay="activeAssay"
                     :analysisInProgress="true"
+                    :filter-id="filterId"
                     v-on:update-selected-term="onUpdateSelectedTerm"
                     v-on:update-selected-taxon-id="onUpdateSelectedTaxonId">
                 </single-dataset-visualizations-card>
@@ -32,7 +33,7 @@ import Component from "vue-class-component";
 import {
     ProteomicsAssay,
     SingleDatasetVisualizationsCard,
-    FunctionalSummaryCard
+    FunctionalSummaryCard, NcbiId
 } from "unipept-web-components";
 import AnalysisSummary from "@/components/analysis/AnalysisSummary.vue";
 
@@ -46,6 +47,10 @@ import AnalysisSummary from "@/components/analysis/AnalysisSummary.vue";
 export default class SingleAssayAnalysisPage extends Vue {
     get activeAssay(): ProteomicsAssay {
         return this.$store.getters.activeAssay?.assay;
+    }
+
+    get filterId(): NcbiId {
+        return this.$store.getters.activeAssay?.filterId;
     }
 
     private onUpdateSelectedTaxonId(id: number) {

--- a/src/logic/communication/analysis/CachedOnlineAnalysisSource.ts
+++ b/src/logic/communication/analysis/CachedOnlineAnalysisSource.ts
@@ -21,7 +21,6 @@ export default class CachedOnlineAnalysisSource implements AnalysisSource {
         const dbVersion = await metadataCommunicator.getCurrentUniprotVersion();
 
         const hash = crypto.createHash("sha256");
-        console.log("Newly computed fingerprint: " + this.endpoint + dbVersion + this.assay.getId());
         hash.update(this.endpoint + dbVersion + this.assay.getId());
 
         return hash.digest("base64");


### PR DESCRIPTION
This PR improves the information displayed about the current state of filtering in the application. A clear information alert is now displayed on top of the page if a filter is active (it is no longer only displayed in the functional information overview) and the peptides shown in the summary table are now also filtered. This means that only the peptides that are associated with the current taxonomic level (or lower) are displayed in the table. 

When exporting the analysis results of the application to a CSV-file we already took into account the currently applied filter, but this was not very clear to the user. With the new alert on top of the page that's added in this PR, we hope to make this less obstructed than before.

The "Export results" button has been moved to the right (underneath the peptide summary table) also to make it more clear that only the information in this table is exported.

**Screenshots:**

<img width="1904" alt="image" src="https://user-images.githubusercontent.com/9608686/161047520-054db3a6-d98d-47b3-8632-da91d5d2da04.png">
