### PR TITLE
Improve error handling for single peptide analysis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "node-abi": "^2.19.3",
         "regenerator-runtime": "^0.13.3",
         "shared-memory-datastructures": "0.1.9",
-        "unipept-web-components": "^1.5.3",
+        "unipept-web-components": "^1.5.4",
         "uuid": "^7.0.3",
         "vue": "^2.6.12",
         "vue-class-component": "^7.1.0",
@@ -21067,9 +21067,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/unipept-web-components": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/unipept-web-components/-/unipept-web-components-1.5.3.tgz",
-      "integrity": "sha512-rnBqsxeaCg7dWHosXVH/XAxIh9uO2mA7sA80ZuB0SqlFQQsJzOXGYjx0vDipClCL0ovsQy0EMJw6wMl0qC9LsQ==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/unipept-web-components/-/unipept-web-components-1.5.4.tgz",
+      "integrity": "sha512-Sxt0a6Uvg3dSRi8TeU+2lHvRqanIcZn8siQsAPTWhWQn9YDXG0Xy2osDa5nv/YbYLHl17eNCZmlJ2kJ5V5Ky2w==",
       "dependencies": {
         "async": "^3.2.0",
         "axios": "^0.21.1",
@@ -40577,9 +40577,9 @@
       }
     },
     "unipept-web-components": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/unipept-web-components/-/unipept-web-components-1.5.3.tgz",
-      "integrity": "sha512-rnBqsxeaCg7dWHosXVH/XAxIh9uO2mA7sA80ZuB0SqlFQQsJzOXGYjx0vDipClCL0ovsQy0EMJw6wMl0qC9LsQ==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/unipept-web-components/-/unipept-web-components-1.5.4.tgz",
+      "integrity": "sha512-Sxt0a6Uvg3dSRi8TeU+2lHvRqanIcZn8siQsAPTWhWQn9YDXG0Xy2osDa5nv/YbYLHl17eNCZmlJ2kJ5V5Ky2w==",
       "requires": {
         "async": "^3.2.0",
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "node-abi": "^2.19.3",
     "regenerator-runtime": "^0.13.3",
     "shared-memory-datastructures": "0.1.9",
-    "unipept-web-components": "^1.5.3",
+    "unipept-web-components": "^1.5.4",
     "uuid": "^7.0.3",
     "vue": "^2.6.12",
     "vue-class-component": "^7.1.0",

--- a/src/components/pages/PeptideAnalysisPage.vue
+++ b/src/components/pages/PeptideAnalysisPage.vue
@@ -1,68 +1,91 @@
 <template>
-    <v-container fluid>
-        <v-row>
-            <v-col>
-                <v-card>
-                    <v-card-text class="mt-0">
-                        <v-text-field
-                            v-on:keyup.enter="openPeptide"
-                            class="pt-0"
-                            v-model="peptideModel"
-                            label="Peptide"
-                            single-line
-                            @click:append-outer="openPeptide"
-                            append-outer-icon="mdi-magnify"
-                            hide-details>
-                        </v-text-field>
-                        <v-checkbox hide-details label="Equate I/L" v-model="equateIlModel"></v-checkbox>
-                    </v-card-text>
-                </v-card>
-            </v-col>
-        </v-row>
+    <div>
+        <v-alert prominent type="error" text class="ma-2" v-if="peptideErrorOccurred">
+            An error occurred while processing this peptide. Details about this specific error are shown below. If you
+            believe that this error is not the result of a user action, then please contact us and provide the error
+            details below. Make sure to check your internet connection before continuing.
 
-        <div v-if="!peptide">
+            <div class="font-weight-bold">Error details</div>
+            <div>{{ peptideErrorObject ? peptideErrorObject.stack : peptideErrorMessage }}</div>
+        </v-alert>
+
+        <v-container fluid>
             <v-row>
                 <v-col>
                     <v-card>
-                        <v-card-text>
-                            <div class="display-1">Tryptic peptide analysis</div>
-                            <div class="subtitle-1">Enter a peptide above to continue...</div>
+                        <v-card-text class="mt-0">
+                            <v-text-field
+                                v-on:keyup.enter="openPeptide"
+                                class="pt-0"
+                                v-model="peptideModel"
+                                label="Peptide"
+                                single-line
+                                @click:append-outer="openPeptide"
+                                append-outer-icon="mdi-magnify"
+                                hide-details>
+                            </v-text-field>
+                            <v-checkbox hide-details label="Equate I/L" v-model="equateIlModel"></v-checkbox>
                         </v-card-text>
                     </v-card>
                 </v-col>
             </v-row>
-        </div>
 
-        <div v-else-if="isAnalysisInProgress">
-            <v-row>
-                <v-col>
-                    <v-card>
-                        <v-card-text class="d-flex flex-column align-center">
-                            <v-progress-circular indeterminate color="primary" size="40" />
-                            <span>Processing your request...</span>
-                        </v-card-text>
-                    </v-card>
-                </v-col>
-            </v-row>
-        </div>
+            <div v-if="!peptide">
+                <v-row>
+                    <v-col>
+                        <v-card>
+                            <v-card-text>
+                                <div class="display-1">Tryptic peptide analysis</div>
+                                <div class="subtitle-1">Enter a peptide above to continue...</div>
+                            </v-card-text>
+                        </v-card>
+                    </v-col>
+                </v-row>
+            </div>
 
-        <div v-else>
-            <v-row>
-                <v-col>
-                    <v-card>
-                        <v-card-text>
-                            <single-peptide-summary />
-                        </v-card-text>
-                    </v-card>
-                </v-col>
-            </v-row>
-            <v-row>
-                <v-col>
-                    <single-peptide-analysis-card />
-                </v-col>
-            </v-row>
-        </div>
-    </v-container>
+            <div v-else-if="isAnalysisInProgress">
+                <v-row>
+                    <v-col>
+                        <v-card>
+                            <v-card-text class="d-flex flex-column align-center">
+                                <v-progress-circular indeterminate color="primary" size="40" />
+                                <span>Processing your request...</span>
+                            </v-card-text>
+                        </v-card>
+                    </v-col>
+                </v-row>
+            </div>
+
+            <div v-else-if="peptideErrorOccurred">
+                <v-row>
+                    <v-col>
+                        <v-card>
+                            <v-card-text>
+                                <span>Information not available...</span>
+                            </v-card-text>
+                        </v-card>
+                    </v-col>
+                </v-row>
+            </div>
+
+            <div v-else>
+                <v-row>
+                    <v-col>
+                        <v-card>
+                            <v-card-text>
+                                <single-peptide-summary />
+                            </v-card-text>
+                        </v-card>
+                    </v-col>
+                </v-row>
+                <v-row>
+                    <v-col>
+                        <single-peptide-analysis-card />
+                    </v-col>
+                </v-row>
+            </div>
+        </v-container>
+    </div>
 </template>
 
 <script lang="ts">
@@ -98,6 +121,18 @@ export default class PeptideAnalysisPage extends Vue {
 
     get isAnalysisInProgress(): boolean {
         return this.$store.getters.peptideStatus.analysisInProgress;
+    }
+
+    get peptideErrorOccurred(): boolean {
+        return this.$store.getters.peptideStatus.error.status;
+    }
+
+    get peptideErrorMessage(): string {
+        return this.$store.getters.peptideStatus.error.message;
+    }
+
+    get peptideErrorObject(): Error {
+        return this.$store.getters.peptideStatus.error.object;
     }
 
     private mounted() {


### PR DESCRIPTION
This PR introduces a fix for #158 by improving the information that's provided when an error occurs in the single peptide analysis component of this application.

Before, the application just kept on loading indefinitely without informing the user about the issue. With this PR, an error message is displayed on top of the page and informs the user about what specifically went wrong.

Screenshots:
![image](https://user-images.githubusercontent.com/9608686/161229481-3e68ba71-4559-483e-8dff-8b2f8ee99940.png)
