### PR TITLE
Fix DB port not used by web container

### DIFF
--- a/src/logic/communication/docker/DockerCommunicator.ts
+++ b/src/logic/communication/docker/DockerCommunicator.ts
@@ -261,6 +261,9 @@ export default class DockerCommunicator {
                     inspectorStream,
                     {
                         name: webContainerName,
+                        Env: [
+                            `DB_PORT=${mysqlPort.toString()}`
+                        ],
                         HostConfig: {
                             PortBindings: {
                                 "3000/tcp": [{


### PR DESCRIPTION
During further testing of the application, I found that apparently the custom database port was not being used by the web container. This means that in some cases (if the database does not run on the default port 3306), the application stopped working. This PR provides a fix for this (but requires that at least v1.0.5 of the Docker web image for Unipept is present on the user's system).