### PR TITLE
Fix setting temporary directory for Docker containers

### DIFF
--- a/src/logic/communication/docker/DockerCommunicator.ts
+++ b/src/logic/communication/docker/DockerCommunicator.ts
@@ -152,7 +152,7 @@ export default class DockerCommunicator {
                                 `${dataVolumeName}:/var/lib/mysql`,
                                 // Mount the folder in which the reusable database index structure will be kept
                                 `${indexVolumeName}:/index`,
-                                `${tempVolumeName}:/temp`
+                                `${tempVolumeName}:/tmp`
                             ]
                         }
                     }


### PR DESCRIPTION
Normally, the application creates a temporary file in the configured database folder and mounts it into the Docker container (such that users can also choose where the temporary files required by the database construction process will be stored). Apparently, the mount point of this temp directory was wrong, causing the Docker database container to always use the same folder on the local filesystem of the user. This PR provides a fix for this problem.