### PR TITLE
Better invalidate cached http requests when changing DBs

### DIFF
--- a/src/components/analysis/ExportResultsButton.vue
+++ b/src/components/analysis/ExportResultsButton.vue
@@ -97,11 +97,6 @@ export default class ExportResultsButton extends Vue {
         if (this.assay && this.peptideCountTable) {
             this.exportLoading = true;
 
-            console.log(this.$store.getters.assayData(this.assay));
-            console.log(this.goOntology);
-            console.log(this.ecOntology);
-            console.log(this.interproOntology);
-
             const csv: string = await PeptideExport.exportSummaryAsCsv(
                 this.peptideCountTable,
                 this.pept2data,

--- a/src/logic/communication/peptides/LocalPept2DataCommunicator.ts
+++ b/src/logic/communication/peptides/LocalPept2DataCommunicator.ts
@@ -30,7 +30,10 @@ export default class LocalPept2DataCommunicator extends Pept2DataCommunicator {
         private readonly customDatabaseLocation: string
     ) {
         super(
-            `${DockerCommunicator.WEB_COMPONENT_PUBLIC_URL}:${DockerCommunicator.WEB_COMPONENT_PUBLIC_PORT}`
+            `${DockerCommunicator.WEB_COMPONENT_PUBLIC_URL}:${DockerCommunicator.WEB_COMPONENT_PUBLIC_PORT}`,
+            // This cache key will be used to make sure that network requests in the cache are invalidated if the
+            // database changes.
+            customDatabase.getDatabaseHash()
         );
     }
 

--- a/src/logic/custom_database/CustomDatabase.ts
+++ b/src/logic/custom_database/CustomDatabase.ts
@@ -61,7 +61,7 @@ export default class CustomDatabase {
      */
     public getDatabaseHash(): string {
         return crypto.createHash("sha256").update(
-            this.sourceTypes.toString() + this.taxa.toString()
+            this.sourceTypes.toString() + this.taxa.toString() + this.entries.toString()
         ).digest("base64");
     }
 }


### PR DESCRIPTION
The desktop app contains a caching mechanism that automatically caches network requests on a per-URL and per-data-object status. However, the URL that's being used to communicate with the Docker containers is always the same (even if the underlying database is different). This means that some requests are wrongly being re-used. This PR fixes this by also taking into account the underlying database properties when computing a cache validation key.