### PR TITLE
Fix assay names too long in sidebar

### DIFF
--- a/src/assets/style/navigation-drawers/assay-item.css.less
+++ b/src/assets/style/navigation-drawers/assay-item.css.less
@@ -12,12 +12,11 @@
   background-color: #F6F6F6;
 }
 
-.assay-item > .assay-name {
-  margin-left: 8px;
-  flex: 1;
+.assay-item .assay-name {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  display: block;
 }
 
 .assay-item--selected {

--- a/src/components/navigation-drawers/AssayItem.vue
+++ b/src/components/navigation-drawers/AssayItem.vue
@@ -78,28 +78,27 @@
                 </v-icon>
             </div>
 
-            <!-- Name of the assay -->
-            <div class="flex-grow-1">
-                <!-- Simply display the name if editing is disabled -->
-                <span
-                    v-if="!isEditingAssayName"
-                    v-on:dblclick="enableAssayEdit()"
-                    class="assay-name">
-                    {{ assay.getName() }}
-                </span>
+            <!-- Simply display the name if editing is disabled -->
+            <span
+                v-if="!isEditingAssayName"
+                v-on:dblclick="enableAssayEdit()"
+                class="assay-name">
+                {{ assay.getName() }}
+            </span>
 
-                <!-- Input field when editing the name is enabled. -->
-                <input
-                    v-else
-                    v-model="assayName"
-                    v-on:blur="disableAssayEdit()"
-                    v-on:keyup.enter="disableAssayEdit()"
-                    :class="{ 'error-item': !isValidAssayName, 'assay-name': true }"
-                    type="text" />
-            </div>
+            <!-- Input field when editing the name is enabled. -->
+            <input
+                v-else
+                v-model="assayName"
+                v-on:blur="disableAssayEdit()"
+                v-on:keyup.enter="disableAssayEdit()"
+                :class="{ 'error-item': !isValidAssayName, 'assay-name': true }"
+                type="text" />
+
+            <v-spacer></v-spacer>
 
             <!-- Icon on the right side of the item -->
-            <div>
+            <div class="ml-2">
                 <!-- When the assay has been fully processed, we show the info button to open up the peptide summary -->
                 <v-tooltip v-if="analysisReady" bottom open-delay="500">
                     <template v-slot:activator="{ on }">
@@ -413,4 +412,6 @@ export default class AssayItem extends Vue {
         position: relative;
         bottom: 1px;
     }
+
+
 </style>


### PR DESCRIPTION
If an assay name was too long, it was not abbreviated in the sidebar, which breaks the lay-out of the application. This PR fixes this issue by showing an ellipsis if an assay's name is too long (if the sidebar's width is increased by the user and more place becomes available, a longer version of the assay's name will also be displayed).