### PR TITLE
Fix database list is only loaded with active Docker connection

### DIFF
--- a/src/logic/communication/docker/DockerCommunicator.ts
+++ b/src/logic/communication/docker/DockerCommunicator.ts
@@ -346,6 +346,10 @@ export default class DockerCommunicator {
     }
 
     public async getDatabaseSize(dbName: string): Promise<number> {
+        if (!DockerCommunicator.connection) {
+            return -1;
+        }
+
         if (!(await this.volumeExists(this.generateDataVolumeName(dbName)))) {
             return -1;
         }


### PR DESCRIPTION
This PR provides a fix for #210. If Docker is inactive, then we cannot query the disk size used by an image. Because we tried this nonetheless, an exception was thrown and the custom database was not added to the list. This is fixed now. If no connection to the Docker deamon can be made, the database size is not shown (but the database itself is).