### PR TITLE
Prevent host from sleeping during DB construction

### DIFF
--- a/src/logic/communication/docker/DockerCommunicator.ts
+++ b/src/logic/communication/docker/DockerCommunicator.ts
@@ -8,6 +8,7 @@ import StringNotifierInspectorStream from "@/logic/communication/docker/StringNo
 import Utils from "@/logic/Utils";
 import FileSystemUtils from "@/logic/filesystem/FileSystemUtils";
 import PortFinder from "portfinder";
+import { powerSaveBlocker } from "@electron/remote";
 
 export default class DockerCommunicator {
     private static readonly BUILD_DB_CONTAINER_NAME = "unipept_desktop_build_database";
@@ -124,7 +125,9 @@ export default class DockerCommunicator {
         const containerName =
             `${DockerCommunicator.BUILD_DB_CONTAINER_NAME}_${this.sanitizeDatabaseName(customDb.name)}`;
 
+
         await new Promise<void>(async(resolve, reject) => {
+            const appSuspensionId = powerSaveBlocker.start("prevent-app-suspension");
             try {
                 await DockerCommunicator.connection.run(
                     DockerCommunicator.UNIPEPT_DB_IMAGE_NAME,
@@ -163,6 +166,8 @@ export default class DockerCommunicator {
             } catch (err) {
                 this.dbBeingConstructed = undefined;
                 reject(err);
+            } finally {
+                powerSaveBlocker.stop(appSuspensionId);
             }
         });
 

--- a/src/state/CustomDatabaseStoreFactory.ts
+++ b/src/state/CustomDatabaseStoreFactory.ts
@@ -5,8 +5,6 @@ import DockerCommunicator from "@/logic/communication/docker/DockerCommunicator"
 import Configuration from "@/logic/configuration/Configuration";
 import * as path from "path";
 import CustomDatabaseManager from "@/logic/filesystem/docker/CustomDatabaseManager";
-import { data } from "jquery";
-import FileSystemUtils from "@/logic/filesystem/FileSystemUtils";
 
 export interface CustomDatabaseState {
     databases: CustomDatabase[],


### PR DESCRIPTION
This PR provides a fix for #203. The `powerSaveBlocker`-feature from Electron is being used to prevent the system from sleeping while a database is being constructed. Note that the display of the system will be allowed to be turned off, but that the OS itself is not allowed to go to sleep. 