### PR TITLE
Bump Unipept Web Components to v1.5.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "raw-loader": "^4.0.2",
         "shared-memory-datastructures": "^0.1.9",
         "ts-loader": "^8.3.0",
-        "unipept-web-components": "^1.5.7",
+        "unipept-web-components": "^1.5.8",
         "uuid": "^8.3.2",
         "vue": "^2.6.14",
         "vue-class-component": "^7.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8241,10 +8241,10 @@ unipept-visualizations@^2.1.0:
     d3 "^6.2.0"
     regenerator-runtime "^0.13.7"
 
-unipept-web-components@^1.5.7:
-  version "1.5.7"
-  resolved "https://registry.yarnpkg.com/unipept-web-components/-/unipept-web-components-1.5.7.tgz#618f5e56a1da4029cba821a04961f0da7393d9a1"
-  integrity sha512-HjbHRLFxucNXlMbtx02mHOjOcYTszPo3hMQoVrRTLp1ydVxNaJnDM3dgdTM7j9iDYVF8wIIj7Q2BbJ2IAGVrTA==
+unipept-web-components@^1.5.8:
+  version "1.5.8"
+  resolved "https://registry.yarnpkg.com/unipept-web-components/-/unipept-web-components-1.5.8.tgz#125b6ecd78a0753830f3ce0cbace139d92f07d81"
+  integrity sha512-LxUyFmr2oGnKYeRS5qHdS9ei9XZv4ZgQnTmLbms1vI13cubWgwGxyXycr20AysMHznuiO+6Jod3LPzaJ3PIVZg==
   dependencies:
     async "^3.2.0"
     axios "^0.21.1"


### PR DESCRIPTION
This PR bumps the Unipept Web Components dependency to version 1.5.8, fixing issue #215.