### PR TITLE
Fix correctly resetting progress when restarting DB construction

### DIFF
--- a/src/state/CustomDatabaseStoreFactory.ts
+++ b/src/state/CustomDatabaseStoreFactory.ts
@@ -162,6 +162,10 @@ export default class CustomDatabaseStoreFactory {
                         progressObj.startTimes[i] = 0;
                         progressObj.endTimes[i] = 0;
                     }
+
+                    progressObj.startTimes[0] = new Date().getTime();
+                    progressObj.currentStep = 0;
+                    progressObj.currentValue = -1;
                 }
 
                 dbObj.ready = status;


### PR DESCRIPTION
When the construction of custom database fails and the construction process is restarted, the progress for this database was not automatically reset at the beginning of the process. This PR provides a fix for this issue.