### PR TITLE
Fix for unknown `host.docker.internal` on Linux

### DIFF
--- a/src/logic/communication/docker/DockerCommunicator.ts
+++ b/src/logic/communication/docker/DockerCommunicator.ts
@@ -275,7 +275,8 @@ export default class DockerCommunicator {
                                     HostIP: "0.0.0.0",
                                     HostPort: DockerCommunicator.WEB_COMPONENT_PUBLIC_PORT
                                 }]
-                            }
+                            },
+                            ExtraHosts: ["host.docker.internal:host-gateway"]
                         }
                     }
                 );


### PR DESCRIPTION
This PR provides a fix for the issue described in #230.