### PR TITLE
Fix study is not always properly deleted

### DIFF
--- a/src/components/navigation-drawers/ProjectExplorer.vue
+++ b/src/components/navigation-drawers/ProjectExplorer.vue
@@ -65,11 +65,11 @@ export default class ProjectExplorer extends Vue {
         // Check which studies already exist, and make sure there isn't one with the same name.
         const unknowns: number[] = this.$store.getters.studies
             .map((s: Study) => s.getName())
-            .filter((s: string) => s.startsWith("Unknown"))
+            .filter((s: string) => s.startsWith("Study name"))
             .map((s: string) => s.replace(/[^0-9]/g, ""))
             .map((s: string) => s === "" ? 0 : parseInt(s));
 
-        let studyName = "Unknown";
+        let studyName = "Study name";
         if (unknowns.length > 0) {
             studyName += ` (${Math.max(...unknowns) + 1})`
         }

--- a/src/components/navigation-drawers/StudyItem.vue
+++ b/src/components/navigation-drawers/StudyItem.vue
@@ -317,6 +317,7 @@ export default class StudyItem extends Vue {
             this.$store.getters.dbManager
         );
         await this.study.accept(studyDestroyer);
+        await this.$store.dispatch("removeStudy", this.study);
     }
 
     private async onSelectAssay(assay: Assay) {


### PR DESCRIPTION
Sometimes, if a user right clicks a study in the ProjectExplorer and tries to delete a study, the study is removed from the filesystem, but the changes are not reflected in the app itself. This PR provides a fix for this issue.