### PR TITLE
Add warning for redundant proteomes

### DIFF
--- a/src/components/custom-database/CreateCustomDatabase.vue
+++ b/src/components/custom-database/CreateCustomDatabase.vue
@@ -140,6 +140,7 @@
                                                 <template v-slot:default>
                                                     <thead>
                                                         <tr>
+                                                            <th class="text-left">Status</th>
                                                             <th class="text-left">Proteome ID</th>
                                                             <th class="text-left">Organism name</th>
                                                             <th class="text-left">Protein count</th>
@@ -147,8 +148,39 @@
                                                         </tr>
                                                     </thead>
                                                     <tbody>
-                                                        <tr v-for="(proteome, index) in referenceProteomes" :key="index">
-                                                            <td>{{ proteome.id }}</td>
+                                                        <tr
+                                                            v-for="(proteome, index) in referenceProteomes"
+                                                            :key="index"
+                                                            :class="{ 'proteome-warning': proteome.redundant }">
+                                                            <td>
+                                                                <v-tooltip
+                                                                    v-if="proteome.redundant"
+                                                                    bottom
+                                                                    open-delay="500">
+                                                                    <template v-slot:activator="{ on }">
+                                                                        <v-icon color="error" v-on="on">
+                                                                            mdi-alert-circle-outline
+                                                                        </v-icon>
+                                                                    </template>
+                                                                    <span>
+                                                                        This proteome is marked as redundant by UniProt
+                                                                        and will not be processed for this database.
+                                                                    </span>
+                                                                </v-tooltip>
+                                                                <v-tooltip v-else bottom open-delay="500">
+                                                                    <template v-slot:activator="{ on }">
+                                                                        <v-icon color="success" v-on="on">
+                                                                            mdi-check
+                                                                        </v-icon>
+                                                                    </template>
+                                                                    <span>
+                                                                        Proteome is ok and will be processed.
+                                                                    </span>
+                                                                </v-tooltip>
+                                                            </td>
+                                                            <td>
+                                                                {{ proteome.id }}
+                                                            </td>
                                                             <td>{{ proteome.organismName }}</td>
                                                             <td>{{ proteome.proteinCount }}</td>
                                                             <td class="text-center">
@@ -600,5 +632,9 @@ export default class CreateCustomDatabase extends Vue {
     .settings-title {
         color: black;
         font-size: 18px;
+    }
+
+    .proteome-warning td {
+        color: red;
     }
 </style>

--- a/src/components/custom-database/CreateCustomDatabase.vue
+++ b/src/components/custom-database/CreateCustomDatabase.vue
@@ -135,6 +135,11 @@
                                 </v-row>
                                 <v-row>
                                     <v-col cols="12">
+                                        <v-alert text type="error" outline v-if="!proteomesAreValid">
+                                            Some of the proteomes you provided have been marked as redundant by
+                                            UniProt. Make sure that all provided proteomes are valid before
+                                            continuing.
+                                        </v-alert>
                                         <div v-if="referenceProteomes.length > 0">
                                             <v-simple-table>
                                                 <template v-slot:default>
@@ -215,7 +220,10 @@
                                 <v-row>
                                     <v-col cols="12">
                                         <v-btn class="mr-1" @click="currentStep--">Go back</v-btn>
-                                        <v-btn color="primary" @click="buildDatabaseFromReferenceProteomes()">
+                                        <v-btn
+                                            color="primary"
+                                            @click="buildDatabaseFromReferenceProteomes()"
+                                            :disabled="!proteomesAreValid || referenceProteomes.length === 0">
                                             Build database
                                         </v-btn>
                                     </v-col>
@@ -373,6 +381,10 @@ export default class CreateCustomDatabase extends Vue {
 
     get totalReferenceProteins(): number {
         return this.referenceProteomes.reduce((acc, proteome) => acc + proteome.proteinCount, 0);
+    }
+
+    get proteomesAreValid(): boolean {
+        return this.referenceProteomes.every(proteome => !proteome.redundant);
     }
 
     private async mounted() {

--- a/src/logic/communication/proteomes/Proteome.ts
+++ b/src/logic/communication/proteomes/Proteome.ts
@@ -9,6 +9,8 @@ export default class Proteome {
         // NCBI ID of the organism to which this proteome is associated.
         public readonly organismId: NcbiId,
         // The amount of proteins that are present in this reference proteome.
-        public readonly proteinCount: number
+        public readonly proteinCount: number,
+        // Has this proteome been marked as redundant by UniProt? (In which case it should no longer be used).
+        public readonly redundant: boolean
     ) {}
 }

--- a/src/logic/communication/proteomes/ProteomeCommunicator.ts
+++ b/src/logic/communication/proteomes/ProteomeCommunicator.ts
@@ -14,8 +14,9 @@ export default class ProteomeCommunicator {
     }
 
     public static async getProteomeById(id: string): Promise<Proteome> {
+        id = id.toUpperCase();
         const result = await NetworkUtils.get(
-            `https://rest.uniprot.org/proteomes/stream?compressed=false&fields=upid%2Corganism%2Corganism_id%2Cprotein_count&format=tsv&query=${id}`
+            `https://rest.uniprot.org/proteomes/stream?compressed=false&fields=upid,organism,organism_id,protein_count&format=tsv&query=(${id})`
         );
 
         const resultLines = result.trimEnd().split("\n");
@@ -24,12 +25,15 @@ export default class ProteomeCommunicator {
             // Only the header is present, we didn't find the requested proteome and return null.
             return null;
         } else if (resultLines.length === 2) {
-            // We found the requested proteome and will return it.
+            // We found the requested proteome, but we are first going to check if its redundant or not.
+            const validProteomes = await NetworkUtils.get(
+                `https://rest.uniprot.org/proteomes/stream?compressed=false&fields=upid,organism,organism_id,protein_count&format=tsv&query=(${id}) AND (proteome_type=1)`
+            );
 
             // Input data is TSV, so we split the fields by a tab-character.
             const data = resultLines[1].split("\t");
             // First field is ID, second is organism name, third is organism ID, fourth is protein count
-            return new Proteome(data[0], data[1], parseInt(data[2]), parseInt(data[3]));
+            return new Proteome(data[0], data[1], parseInt(data[2]), parseInt(data[3]), !validProteomes.includes(id));
         } else {
             // Multiple reference proteomes with this ID were found and an error will be thrown in this case.
             throw new Error(`Invalid reference proteome ID ${id} was provided.`);


### PR DESCRIPTION
This PR provides a solution for #237. If a redundant proteome has been entered, it will be marked with an invalid status symbol and the complete row will be red:

<img width="1223" alt="image" src="https://user-images.githubusercontent.com/9608686/195057961-63fea7b7-86f9-4fa8-bda0-0b433b2112f9.png">
