### PR TITLE
Bump Unipept Web Components to v1.5.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "raw-loader": "^4.0.2",
         "shared-memory-datastructures": "^0.1.9",
         "ts-loader": "^8.3.0",
-        "unipept-web-components": "^1.5.8",
+        "unipept-web-components": "^1.5.9",
         "uuid": "^8.3.2",
         "vue": "^2.6.14",
         "vue-class-component": "^7.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8246,10 +8246,10 @@ unipept-visualizations@^2.1.0:
     d3 "^6.2.0"
     regenerator-runtime "^0.13.7"
 
-unipept-web-components@^1.5.8:
-  version "1.5.8"
-  resolved "https://registry.yarnpkg.com/unipept-web-components/-/unipept-web-components-1.5.8.tgz#125b6ecd78a0753830f3ce0cbace139d92f07d81"
-  integrity sha512-LxUyFmr2oGnKYeRS5qHdS9ei9XZv4ZgQnTmLbms1vI13cubWgwGxyXycr20AysMHznuiO+6Jod3LPzaJ3PIVZg==
+unipept-web-components@^1.5.9:
+  version "1.5.9"
+  resolved "https://registry.yarnpkg.com/unipept-web-components/-/unipept-web-components-1.5.9.tgz#319f67baf0ddaa8ab2531ac5a179ce59c47157b4"
+  integrity sha512-IIyY0hXk//oWioiaNLIg8vmbpaDTcT2qsX8nfyeKZlFHlfMFyP8V/hBzCAjFzP/vxBysp9qojuIgMrJ7ksYuYQ==
   dependencies:
     async "^3.2.0"
     axios "^0.21.1"


### PR DESCRIPTION
This PR upgrades the Unipept Web Components dependency to version 1.5.9. This fixes the following two issues:

* Downloading an SVG file of the heatmap does not work (#227)
* Downloading a functional summary for the functional annotations of a peptide does not work.