### PR TITLE
Bump Unipept Web Components to v1.5.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "raw-loader": "^4.0.2",
         "shared-memory-datastructures": "^0.1.9",
         "ts-loader": "^8.3.0",
-        "unipept-web-components": "^1.5.9",
+        "unipept-web-components": "^1.5.10",
         "uuid": "^8.3.2",
         "vue": "^2.6.14",
         "vue-class-component": "^7.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8243,10 +8243,10 @@ unipept-visualizations@^2.1.0:
     d3 "^6.2.0"
     regenerator-runtime "^0.13.7"
 
-unipept-web-components@^1.5.9:
-  version "1.5.9"
-  resolved "https://registry.yarnpkg.com/unipept-web-components/-/unipept-web-components-1.5.9.tgz#319f67baf0ddaa8ab2531ac5a179ce59c47157b4"
-  integrity sha512-IIyY0hXk//oWioiaNLIg8vmbpaDTcT2qsX8nfyeKZlFHlfMFyP8V/hBzCAjFzP/vxBysp9qojuIgMrJ7ksYuYQ==
+unipept-web-components@^1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/unipept-web-components/-/unipept-web-components-1.5.10.tgz#f432ee43b0ddd892e70588a66a9498f83b0deb6d"
+  integrity sha512-8hvc1WhdLDRB+2wWdPHwHtvG1P8BsplIcZM099dyiOJf8SOCvPkGAoPwh1G6VC+3tWAt7TxT3GeBdHp3LtwK7g==
   dependencies:
     async "^3.2.0"
     axios "^0.21.1"


### PR DESCRIPTION
This PR bumps the Unipept Web Components dependency to v1.5.10 which should fix the issue that exporting functional annotations to CSV-files did not work (it did work in development builds of the application, but not in the production build).