### PR TITLE
Add custom online endpoints

### DIFF
--- a/src/components/assay/CreateAssayDialog.vue
+++ b/src/components/assay/CreateAssayDialog.vue
@@ -356,13 +356,17 @@ export default class CreateAssayDialog extends Vue {
         }
     }
 
-    private created() {
-        // Reset the current state of the component when it is reopened.
-        this.renderableSources.push({
-            type: "online",
-            title: "Online Unipept service",
-            subtitle: "https://rick.ugent.be"
-        });
+    private async created() {
+        const configMng = new ConfigurationManager();
+        const config = await configMng.readConfiguration();
+
+        for (const endpoint of config.endpoints) {
+            this.renderableSources.push({
+                type: "online",
+                title: `Online service (${endpoint})`,
+                subtitle: endpoint
+            });
+        }
 
         for (const dbInfo of (this.$store.getters["customDatabases/databases"] as CustomDatabase[])) {
             if (dbInfo.ready) {

--- a/src/logic/application/BootstrapApplication.ts
+++ b/src/logic/application/BootstrapApplication.ts
@@ -35,7 +35,7 @@ export default class BootstrapApplication {
     }
 
     private initializeApi(config: Configuration): void {
-        NetworkConfiguration.BASE_URL = "https://rick.ugent.be";
+        NetworkConfiguration.BASE_URL = "https://api.unipept.ugent.be";
 
         // NetworkConfiguration.BASE_URL = config.apiSource;
         //

--- a/src/logic/configuration/Configuration.ts
+++ b/src/logic/configuration/Configuration.ts
@@ -5,4 +5,6 @@ export default interface Configuration {
     customDbStorageLocation: string;
     // The version of the application that was used to create this configuration.
     configurationAppVersion: string;
+    // List of custom Unipept endpoints that were provided to this app.
+    endpoints: string[];
 }


### PR DESCRIPTION
This PR introduces a new feature that allows the user to add custom online endpoints in the settings page. These can then be selected, per sample, before starting an analysis.

**Screenshot:**
<img width="1431" alt="image" src="https://user-images.githubusercontent.com/9608686/201931998-2d9a2cb7-93c2-48ed-b4f7-2364963f56f0.png">
