### PR TITLE
Bump Unipept Web Components to v1.5.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "raw-loader": "^4.0.2",
         "shared-memory-datastructures": "^0.1.9",
         "ts-loader": "^8.3.0",
-        "unipept-web-components": "^1.5.10",
+        "unipept-web-components": "^1.5.11",
         "uuid": "^8.3.2",
         "vue": "^2.6.14",
         "vue-class-component": "^7.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "unipept-desktop",
-    "version": "2.0.0-alpha.10",
+    "version": "2.0.0-alpha.11",
     "productName": "Unipept Desktop",
     "private": false,
     "author": "Unipept Team (Ghent University)",


### PR DESCRIPTION
This PR bumps the Unipept Web Components dependency to version 1.5.11 which provides a hotfix for an issue when downloading SVG images.