### PR TITLE
Added a devcontainer that supports development of the desktop application

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+
+RUN apt update
+RUN apt install --yes xfce4 xfce4-goodies gnome-icon-theme dbus-x11 xfce4-terminal tightvncserver
+# Register xfce4-terminal as an alternative for x-terminal-emulator
+RUN update-alternatives --install /usr/bin/x-terminal-emulator x-terminal-emulator /usr/bin/xfce4-terminal 50
+# Set xfce4-terminal as the default x-terminal-emulator
+RUN update-alternatives --set x-terminal-emulator /usr/bin/xfce4-terminal
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+// In order to view the electron application and test it locally, you need to open a VNC viewer, connect to
+// localhost:5901 and use password unipept.
+
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/anaconda
+{
+  "name": "Unipept Desktop",
+  "build": { "dockerfile": "Dockerfile" },
+
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  "features": {
+    "ghcr.io/devcontainers/features/node:1":  {
+      "version": "lts/gallium"
+    },
+  },
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [5901],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "sudo ./.devcontainer/setup.sh",
+
+  // Configure tool-specific properties.
+  // "customizations": {},
+
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+touch .Xauthority
+
+umask 0077
+mkdir -p "$HOME/.vnc"
+chmod go-rwx "$HOME/.vnc"
+vncpasswd -f <<<"unipept" >"$HOME/.vnc/passwd"
+vncserver -geometry 1920x1080

--- a/unipept-desktop.iml
+++ b/unipept-desktop.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7282,7 +7282,7 @@ rw@1:
   resolved "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz"
   integrity sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==
 
-rxjs@*:
+rxjs@^7.5.2:
   version "7.8.1"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"
   integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==


### PR DESCRIPTION
This PR introduces a `devcontainer.json` file in which a VNC server is running. This way, you can collect to this VNC server locally and run the Unipept Desktop application (for development) in a Docker container, keeping your local system clean.

In order to do so, open a VNC viewer (like RealVNC) and connect to `localhost:5901`. The default password is `unipept`.

Screenshot:

![image](https://github.com/user-attachments/assets/19324b5a-7bfe-459d-bb65-13d7dff98cd4)
